### PR TITLE
feat(config): add mysql ALPN to port maps

### DIFF
--- a/dynamic-config.go
+++ b/dynamic-config.go
@@ -31,6 +31,7 @@ var rawPortMap = map[string]uint16{
 	"irc":         6697,
 	"managesieve": 4190,
 	"mqtt":        8883,
+	"mysql":       3306,
 	"nntp":        563,
 	"ntske/1":     4460,
 	"ntske":       4460, // SRV shorthand
@@ -63,6 +64,7 @@ var terminatedPortMap = map[string]uint16{
 	"irc":         16667,
 	"managesieve": 14190,
 	"mqtt":        11883,
+	"mysql":       13306,
 	"nntp":        10119,
 	"ntske/1":     10123,
 	"ntske":       10123, // SRV shorthand


### PR DESCRIPTION
Just like we fudge this for `ssh`, we'll also fudge it for `mysql`.

## Summary

- Adds `mysql` to `rawPortMap` (port 3306) for direct TLS passthrough
- Adds `mysql` to `terminatedPortMap` (port 13306) for TLS-terminated connections

This enables MariaDB/MySQL routing through the TLS Router via `sclient --alpn mysql`. The backend expects `tcpfwd 13306:<backend-ip>:3306` to be running on the target host.

## Test plan

- [ ] Verify `sclient --alpn mysql tls-<ip>.<domain>:443 localhost:23306` connects to MariaDB
- [ ] Verify `mariadb --host=127.0.0.1 --port=23306 --skip-ssl -e "SELECT 1"` succeeds through the tunnel