### PR TITLE
fix(proxy): strip X-Real-IP

### DIFF
--- a/tlsrouter.go
+++ b/tlsrouter.go
@@ -561,7 +561,8 @@ func NewListenConfig(conf Config) *ListenConfig {
 				proxy := &httputil.ReverseProxy{
 					Rewrite: func(r *httputil.ProxyRequest) {
 						r.SetURL(target)
-						r.Out.Host = r.In.Host // preserve Host header
+						r.Out.Host = r.In.Host        // preserve Host header
+						r.Out.Header.Del("X-Real-IP") // not auto-stripped
 						r.SetXForwarded()
 						r.Out.Header["X-Forwarded-Proto"] = []string{"https"} // preserve https
 					},


### PR DESCRIPTION
Rewrite mode auto-strips Forwarded and X-Forwarded-*. X-Real-IP is not in that set, so client-sent values pass through. Strip it.

Test: `curl -H 'X-Real-IP: 1.2.3.4' https://<domain>/` — backend should not see it.