### PR TITLE
fix(admin): h2 ALPN by injecting *tls.Conn into HTTPTunnel

### DIFF
--- a/tlsrouter.go
+++ b/tlsrouter.go
@@ -1079,7 +1079,9 @@ func (lc *ListenConfig) proxy(conn net.Conn) (r int64, w int64, retErr error) {
 	if backend.HTTPTunnel != nil {
 		fmt.Fprintf(os.Stderr, "DEBUG: %s: HANDLING > backend.HTTPTunnel.Inject\n", snialpn)
 		// doesn't block
-		retErr = backend.HTTPTunnel.Inject(wconn.PlainConn)
+		// Inject *tls.Conn (not PlainConn wrapper) so http.Server's
+		// rwc.(*tls.Conn) assertion sees TLS and uses ALPN to pick h2 vs h1.
+		retErr = backend.HTTPTunnel.Inject(tlsConn)
 		wconn.wg.Wait()
 	} else if beConn != nil {
 		fmt.Fprintf(os.Stderr, "DEBUG: %s: HANDLING > TunnelTCPConn(cConn, beConn)\n", snialpn)


### PR DESCRIPTION
## Summary

`http.Server` uses a concrete `rwc.(*tls.Conn)` type assertion to detect TLS and read `NegotiatedProtocol`. `PlainConn` embeds `*tls.Conn` but is a distinct concrete type, so the assertion fails. Server falls back to HTTP/1.x and writes a non-h2 response to the client's h2 preface.

Repro:

```
$ curl -sS --http2 -i https://vms.coolaj86.com/version
curl: (16) Remote peer returned unexpected data while we expected SETTINGS frame.
$ curl -sS --http1.1 -i https://vms.coolaj86.com/version
HTTP/1.1 200 OK ...
```

Inject `tlsConn` directly so the server sees `*tls.Conn` and negotiates h2/h1 via ALPN. Trade-off: `PlainConn`'s plaintext byte counters no longer apply on this path; outer `wconn` still counts wire bytes.

## Test plan
- [x] build on deploy host
- [x] redeploy tlsrouter to vms.coolaj86.com
- [x] `curl --http2 https://vms.coolaj86.com/version` returns 200
- [x] `curl --http1.1 https://vms.coolaj86.com/version` still returns 200