### PR TITLE
fix(proxy): wire X-Forwarded-* handling for dynamic services

### DIFF
--- a/dynamic-config.go
+++ b/dynamic-config.go
@@ -128,6 +128,13 @@ func (lc *ListenConfig) getOrCreateHostConfig(
 	// TODO check that a backend exists here
 	// (any cached slowMatchConfig should do since what triggers that triggers this)
 
+	// Match the static-config init path: HTTP-family terminated services get
+	// a ReverseProxy so X-Forwarded-* are re-set from the trusted inbound conn
+	// instead of passed through from the untrusted client.
+	if terminate && slices.Contains(HTTPFamilyALPNs, selectedALPN) {
+		lc.setupHTTPReverseProxy(&backend)
+	}
+
 	// Create service configuration
 	service := &ConfigService{
 		Slug:                   serviceSlug,

--- a/tlsrouter.go
+++ b/tlsrouter.go
@@ -548,71 +548,7 @@ func NewListenConfig(conf Config) *ListenConfig {
 			alpn := snialpn.ALPN()
 			fmt.Fprintf(os.Stderr, "DEBUG: %s: incoming snialpn %s\n", domain, alpn)
 			if alpn == "h2" || alpn == "h3" || alpn == "http/1.1" || backend.ForceHTTP {
-				backend.HTTPTunnel = tun.NewListener(lc.Context)
-
-				target := &url.URL{
-					Scheme: "http",
-					Host:   backend.Host,
-				}
-				if backend.ConnectTLS {
-					target.Scheme = "https"
-				}
-
-				proxy := &httputil.ReverseProxy{
-					Rewrite: func(r *httputil.ProxyRequest) {
-						r.SetURL(target)
-						r.Out.Host = r.In.Host        // preserve Host header
-						r.Out.Header.Del("X-Real-IP") // not auto-stripped
-						r.SetXForwarded()
-						r.Out.Header["X-Forwarded-Proto"] = []string{"https"} // preserve https
-					},
-				}
-
-				// default transport https://pkg.go.dev/net/http#DefaultTransport
-				dialer := &net.Dialer{
-					// Timeout:       30 * time.Second,
-					Timeout:       400 * time.Millisecond, // TODO check internal/external, make user-configurable
-					FallbackDelay: 300 * time.Millisecond,
-					KeepAlive:     30 * time.Second,
-				}
-				transport := &http.Transport{
-					Proxy:                 http.ProxyFromEnvironment,
-					DialContext:           dialer.DialContext,
-					ForceAttemptHTTP2:     true,
-					MaxIdleConns:          100,
-					IdleConnTimeout:       90 * time.Second,
-					TLSHandshakeTimeout:   10 * time.Second,
-					ExpectContinueTimeout: 1 * time.Second,
-				}
-
-				// custom
-				protocols := &http.Protocols{}
-				protocols.SetHTTP1(true)
-				protocols.SetHTTP2(true)
-				protocols.SetUnencryptedHTTP2(true)
-				transport.Protocols = protocols
-
-				// I'll trust the Go authors' choice of ciphers:
-				// https://cs.opensource.google/go/go/+/refs/tags/go1.24.3:src/crypto/tls/cipher_suites.go;l=56
-				// hasAES := cpu.X86.HasAES || cpu.ARM64.HasAES || cpu.ARM.HasAES || cpu.S390X.HasAES || cpu.RISCV64.HasZvkn
-				transport.TLSClientConfig = &tls.Config{}
-				if backend.SkipTLSVerify {
-					transport.TLSClientConfig.InsecureSkipVerify = true
-				}
-				proxy.Transport = transport
-
-				// TODO track these for shutdown (to call Shutdown() and Close() on each)
-				proxyServer := &http.Server{
-					Handler: proxy,
-					BaseContext: func(_ net.Listener) context.Context {
-						return lc.Context
-					},
-					ConnContext: nil,
-					Protocols:   protocols,
-				}
-				go func() {
-					_ = proxyServer.Serve(backend.HTTPTunnel)
-				}()
+				lc.setupHTTPReverseProxy(&backend)
 				m.Backends[beIndex] = backend
 			}
 		}
@@ -621,6 +557,72 @@ func NewListenConfig(conf Config) *ListenConfig {
 	// Now we must never modify conf again!!
 	lc.StoreConfig(conf)
 	return lc
+}
+
+// setupHTTPReverseProxy installs an httputil.ReverseProxy + http.Server on
+// backend.HTTPTunnel so HTTP-family traffic has X-Forwarded-* re-set from the
+// trusted inbound request (http.ReverseProxy.Rewrite strips them by design).
+// Callers must have already chosen an HTTP-family ALPN for the backend.
+func (lc *ListenConfig) setupHTTPReverseProxy(backend *Backend) {
+	backend.HTTPTunnel = tun.NewListener(lc.Context)
+
+	target := &url.URL{
+		Scheme: "http",
+		Host:   backend.Host,
+	}
+	if backend.ConnectTLS {
+		target.Scheme = "https"
+	}
+
+	proxy := &httputil.ReverseProxy{
+		Rewrite: func(r *httputil.ProxyRequest) {
+			r.SetURL(target)
+			r.Out.Host = r.In.Host        // preserve Host header
+			r.Out.Header.Del("X-Real-IP") // not auto-stripped
+			r.SetXForwarded()
+			r.Out.Header["X-Forwarded-Proto"] = []string{"https"} // preserve https
+		},
+	}
+
+	// default transport https://pkg.go.dev/net/http#DefaultTransport
+	dialer := &net.Dialer{
+		Timeout:       400 * time.Millisecond, // TODO check internal/external, make user-configurable
+		FallbackDelay: 300 * time.Millisecond,
+		KeepAlive:     30 * time.Second,
+	}
+	transport := &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           dialer.DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+
+	protocols := &http.Protocols{}
+	protocols.SetHTTP1(true)
+	protocols.SetHTTP2(true)
+	protocols.SetUnencryptedHTTP2(true)
+	transport.Protocols = protocols
+
+	transport.TLSClientConfig = &tls.Config{}
+	if backend.SkipTLSVerify {
+		transport.TLSClientConfig.InsecureSkipVerify = true
+	}
+	proxy.Transport = transport
+
+	// TODO track these for shutdown (to call Shutdown() and Close() on each)
+	proxyServer := &http.Server{
+		Handler: proxy,
+		BaseContext: func(_ net.Listener) context.Context {
+			return lc.Context
+		},
+		Protocols: protocols,
+	}
+	go func() {
+		_ = proxyServer.Serve(backend.HTTPTunnel)
+	}()
 }
 
 func (lc *ListenConfig) StoreConfig(conf Config) {


### PR DESCRIPTION
## Summary

Dynamic IP/SRV/CNAME matched services (`getOrCreateHostConfig`) created a `Backend` but never attached an `HTTPTunnel` + `ReverseProxy`. HTTP traffic for those services took the raw TCP tunnel path (`TunnelTCPConn`), bypassing `Rewrite`/`SetXForwarded` entirely — so clients could spoof `X-Forwarded-For` / `X-Real-IP` end-to-end.

Extract the existing static-init ReverseProxy setup into `setupHTTPReverseProxy(*Backend)` and call it from both the static init loop and the dynamic path (when `terminate && HTTPFamilyALPNs`).

## Test plan
- [x] deploy to staging/prod
- [x] curl a dynamic-matched HTTPS host with spoofed `X-Forwarded-For: 1.2.3.4`, `X-Real-IP: 1.2.3.4`
- [x] verify backend sees router-set values (real client IP), not the spoofed ones
- [x] verify static backends still work (no regression)