### PR TITLE
fix(proxy): route all offered ALPNs through CNAME path

### DIFF
--- a/dynamic-config.go
+++ b/dynamic-config.go
@@ -273,8 +273,10 @@ func getAllowedSrv(
 	}
 
 	alpnsLen := len(alpns)
-	cnameOptions := 2
-	options := make([]*srvOption, alpnsLen+cnameOptions)
+	// options layout: [CNAME results | SRV results], same ALPN order in each half
+	cnameOffset := 0
+	srvOffset := alpnsLen
+	options := make([]*srvOption, alpnsLen+alpnsLen)
 
 	var wg sync.WaitGroup
 	ipQueries := 2
@@ -332,14 +334,15 @@ func getAllowedSrv(
 			portMap = rawPortMap
 		}
 
-		c := len(options)
-		if slices.Contains(alpns, "ssh") {
-			options[c-2] = &srvOption{alpn: "ssh", ip: ip, terminate: terminate, port: terminatedPortMap["ssh"]}
+		for i, alpn := range alpns {
+			port, ok := portMap[alpn]
+			if !ok {
+				continue
+			}
+			cnameMatch = true
+			options[cnameOffset+i] = &srvOption{alpn: alpn, ip: ip, terminate: terminate, port: port}
 		}
-		if slices.Contains(alpns, "http/1.1") {
-			options[c-1] = &srvOption{alpn: "http/1.1", ip: ip, terminate: terminate, port: portMap["http/1.1"]}
-		}
-		dbg("DEBUG: %s: CNAME to ip: ssh,http (low-priority default), %s, terminate: %t", domain, ip.String(), terminate)
+		dbg("DEBUG: %s: CNAME to ip: %d ALPNs, %s, terminate: %t", domain, len(alpns), ip.String(), terminate)
 	}()
 	go func() {
 		defer wg.Done()
@@ -363,7 +366,7 @@ func getAllowedSrv(
 			defer wg.Done()
 
 			if ip, terminate, port, err := findSrvForALPN(conf, domain, alpn); err == nil {
-				options[index] = &srvOption{alpn: alpn, ip: ip, terminate: terminate, port: port}
+				options[srvOffset+index] = &srvOption{alpn: alpn, ip: ip, terminate: terminate, port: port}
 			}
 		}(alpn, idx)
 	}


### PR DESCRIPTION
## Summary
- Route all offered ALPNs through the CNAME resolution path, not just hardcoded ssh and http/1.1
- CNAME is the primary resolution path (target IP extracted from domain label); SRV is the alternative
- Options layout reordered to [CNAME results | SRV results] to reflect priority
- Only set `cnameMatch` when an offered ALPN actually matches the port map

## Test plan
- [x] CNAME routing (domain with CNAME to tls- IP domain): ssh and http/1.1 both route correctly
- [x] SRV routing (domain with A record only, no CNAME): ssh and http/1.1 both route correctly
- [x] Non-matching ALPNs rejected correctly (checkSRV returns "unsupported ALPN or port mismatch")
- [x] Direct IP domain routing (tls- prefix) still works
- [x] Static config domains unaffected