### PR TITLE
fix(proxy): skip_tls_verify CSV header + Referer/Origin rewrite for connect_tls

### DIFF
--- a/configfile.go
+++ b/configfile.go
@@ -265,7 +265,7 @@ func ReadCSVToConfig(r *csv.Reader) (*Config, error) {
 			connectTLS = true
 		}
 		connectInsecure := false
-		if i, ok := headerIndices["connect_insecure"]; ok && i < len(record) && strings.ToLower(record[i]) == "true" {
+		if i, ok := headerIndices["skip_tls_verify"]; ok && i < len(record) && strings.ToLower(record[i]) == "true" {
 			connectInsecure = true
 		}
 		allowedClientHostnames := []string{}

--- a/tlsrouter.go
+++ b/tlsrouter.go
@@ -577,7 +577,13 @@ func (lc *ListenConfig) setupHTTPReverseProxy(backend *Backend) {
 	proxy := &httputil.ReverseProxy{
 		Rewrite: func(r *httputil.ProxyRequest) {
 			r.SetURL(target)
-			r.Out.Host = r.In.Host        // preserve Host header
+			if backend.ConnectTLS {
+				inHost := r.In.Host
+				rewriteHeaderHost(r.Out.Header, "Referer", inHost, target.Host)
+				rewriteHeaderHost(r.Out.Header, "Origin", inHost, target.Host)
+			} else {
+				r.Out.Host = r.In.Host // preserve original Host for plaintext backends
+			}
 			r.Out.Header.Del("X-Real-IP") // not auto-stripped
 			// We are the trust boundary: r.In.RemoteAddr is the real
 			// client, so SetXForwarded produces the authoritative
@@ -638,6 +644,22 @@ func (lc *ListenConfig) setupHTTPReverseProxy(backend *Backend) {
 	go func() {
 		_ = proxyServer.Serve(backend.HTTPTunnel)
 	}()
+}
+
+func rewriteHeaderHost(h http.Header, key, oldHost, newHost string) {
+	val := h.Get(key)
+	if val == "" {
+		return
+	}
+	u, err := url.Parse(val)
+	if err != nil {
+		h.Del(key)
+		return
+	}
+	if u.Host == oldHost {
+		u.Host = newHost
+		h.Set(key, u.String())
+	}
 }
 
 func (lc *ListenConfig) StoreConfig(conf Config) {

--- a/tlsrouter.go
+++ b/tlsrouter.go
@@ -588,6 +588,10 @@ func (lc *ListenConfig) setupHTTPReverseProxy(backend *Backend) {
 			r.SetXForwarded()
 			r.Out.Header["X-Forwarded-Proto"] = []string{"https"} // TLS terminated here
 		},
+		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
+			log.Printf("reverse proxy error for %s: %v", r.Host, err)
+			w.WriteHeader(http.StatusBadGateway)
+		},
 	}
 
 	// default transport https://pkg.go.dev/net/http#DefaultTransport


### PR DESCRIPTION
## Summary
- Fix CSV header mismatch: parser looked for `connect_insecure` but the header is `skip_tls_verify`, so the field was silently ignored — backends with self-signed certs got `x509: cannot validate certificate` errors
- Rewrite the domain portion of Referer and Origin headers for connect_tls backends instead of passing through the external hostname, which triggers DNS rebind / referrer checks on appliances like pfSense

## Test plan
- [x] `skip_tls_verify=true` propagates at runtime (`SkipTLSVerify=true` in debug output)
- [x] pfSense backend proxies successfully with self-signed cert
- [x] Referer/Origin rewritten to backend target host for connect_tls backends
- [x] Plaintext backends still preserve original Host header
- [x] Deployed and verified on live server