### PR TITLE
feat(auth): add auth gate for terminated HTTP backends

### DIFF
--- a/api.go
+++ b/api.go
@@ -12,8 +12,8 @@ import (
 	"time"
 )
 
-type BasicAuthVerifier interface {
-	Verify(string, string) bool
+type BasicVerifier interface {
+	Verify(string, string) error
 }
 
 // JSONError represents an API error response
@@ -136,8 +136,12 @@ func WConnToPConn(wconn *wrappedConn) PConn {
 
 func (c *Config) requireToken(w http.ResponseWriter, r *http.Request) bool {
 	_, password, ok := r.BasicAuth()
+	if !ok {
+		jsonError(w, http.StatusUnauthorized, "unauthorized", "Unauthorized", "Invalid credentials")
+		return false
+	}
 
-	if !ok || !c.TabVault.Verify(c.AdminDNS.AdminToken, password) {
+	if err := c.TabVault.Verify(c.AdminDNS.AdminToken, password); err != nil {
 		jsonError(w, http.StatusUnauthorized, "unauthorized", "Unauthorized", "Invalid credentials")
 		return false
 	}

--- a/cmd/tabvault/main.go
+++ b/cmd/tabvault/main.go
@@ -54,12 +54,12 @@ func main() {
 			os.Exit(1)
 		}
 		password := readSecret()
-		if tabVault.Verify(args[2], password) {
-			fmt.Fprintln(os.Stderr, "OK")
-			os.Exit(0)
+		if tabVault.Verify(args[2], password) != nil {
+			fmt.Fprintln(os.Stderr, "FAIL")
+			os.Exit(1)
 		}
-		fmt.Fprintln(os.Stderr, "FAIL")
-		os.Exit(1)
+		fmt.Fprintln(os.Stderr, "OK")
+		os.Exit(0)
 	default:
 		mainFlags.Usage()
 		os.Exit(1)

--- a/configfile.go
+++ b/configfile.go
@@ -196,10 +196,13 @@ var expectedHeaders = []string{
 	"terminate_tls",
 	"connect_tls",
 	"skip_tls_verify",
+	"auth",
 	"allowed_client_hostnames",
 }
 
 func ReadCSVToConfig(r *csv.Reader) (*Config, error) {
+	r.FieldsPerRecord = -1
+
 	config := &Config{
 		AdminDNS: ConfigAdmin{},
 		Apps:     []ConfigApp{},
@@ -267,6 +270,10 @@ func ReadCSVToConfig(r *csv.Reader) (*Config, error) {
 		connectInsecure := false
 		if i, ok := headerIndices["skip_tls_verify"]; ok && i < len(record) && strings.ToLower(record[i]) == "true" {
 			connectInsecure = true
+		}
+		authToken := ""
+		if i, ok := headerIndices["auth"]; ok && i < len(record) && record[i] != "" {
+			authToken = record[i]
 		}
 		allowedClientHostnames := []string{}
 		if i, ok := headerIndices["allowed_client_hostnames"]; ok && i < len(record) && record[i] != "" {
@@ -385,6 +392,7 @@ func ReadCSVToConfig(r *csv.Reader) (*Config, error) {
 				TerminateTLS:  terminateTLS,
 				ConnectTLS:    connectTLS,
 				SkipTLSVerify: connectInsecure,
+				AuthToken:     authToken,
 			}
 			service.Backends = append(service.Backends, backend)
 		}
@@ -424,6 +432,7 @@ type CSVRecord struct {
 	TerminateTLS           bool
 	ConnectTLS             bool
 	SkipTLSVerify          bool
+	Auth                   string
 	AllowedClientHostnames string
 }
 
@@ -455,6 +464,7 @@ func (c *Config) ToRecords() ([]CSVRecord, error) {
 							TerminateTLS:           backend.TerminateTLS,
 							ConnectTLS:             backend.ConnectTLS,
 							SkipTLSVerify:          backend.SkipTLSVerify,
+							Auth:                   backend.AuthToken,
 							AllowedClientHostnames: strings.Join(service.AllowedClientHostnames, ";"),
 						})
 					}
@@ -495,6 +505,9 @@ func (c *Config) ToRecords() ([]CSVRecord, error) {
 		if a.SkipTLSVerify != b.SkipTLSVerify {
 			return strings.Compare(fmt.Sprintf("%t", a.SkipTLSVerify), fmt.Sprintf("%t", b.SkipTLSVerify))
 		}
+		if a.Auth != b.Auth {
+			return strings.Compare(a.Auth, b.Auth)
+		}
 		return strings.Compare(a.AllowedClientHostnames, b.AllowedClientHostnames)
 	})
 
@@ -519,6 +532,7 @@ func RecordsToCSV(csvw *csv.Writer, records []CSVRecord) error {
 			fmt.Sprintf("%t", record.TerminateTLS),
 			fmt.Sprintf("%t", record.ConnectTLS),
 			fmt.Sprintf("%t", record.SkipTLSVerify),
+			record.Auth,
 			record.AllowedClientHostnames,
 		}
 		if err := csvw.Write(csvRow); err != nil {

--- a/dynamic-config.go
+++ b/dynamic-config.go
@@ -132,7 +132,7 @@ func (lc *ListenConfig) getOrCreateHostConfig(
 	// a ReverseProxy so X-Forwarded-* are re-set from the trusted inbound conn
 	// instead of passed through from the untrusted client.
 	if terminate && slices.Contains(HTTPFamilyALPNs, selectedALPN) {
-		lc.setupHTTPReverseProxy(&backend)
+		lc.setupHTTPReverseProxy(domain, &backend, conf.TabVault)
 	}
 
 	// Create service configuration

--- a/tabvault/tabvault.go
+++ b/tabvault/tabvault.go
@@ -9,6 +9,7 @@ import (
 	"encoding/base64"
 	"encoding/csv"
 	"encoding/hex"
+	"errors"
 	"os"
 	"strconv"
 	"strings"
@@ -143,18 +144,23 @@ func (v *TabVault) Get(id string) string {
 	return v.secrets[strings.TrimPrefix(id, "vault://")]
 }
 
+var ErrInvalidCredentials = errors.New("invalid credentials")
+
 type BasicAuthPassword string
 
-func (p BasicAuthPassword) Verify(_, password string) bool {
+func (p BasicAuthPassword) Verify(_, password string) error {
 	known := sha256.Sum256([]byte(p))
 	digest := sha256.Sum256([]byte(password))
-	return bytes.Equal(known[:], digest[:])
+	if !bytes.Equal(known[:], digest[:]) {
+		return ErrInvalidCredentials
+	}
+	return nil
 }
 
-func (v *TabVault) Verify(id string, password string) bool {
+func (v *TabVault) Verify(id string, password string) error {
 	secret := v.Get(id)
 	if secret == "" {
-		return false
+		return ErrInvalidCredentials
 	}
 
 	if !strings.HasPrefix(secret, phcPrefix) {
@@ -165,28 +171,31 @@ func (v *TabVault) Verify(id string, password string) bool {
 	inner := secret[1:]
 	parts := strings.SplitN(inner, "$", 4)
 	if len(parts) != 4 {
-		return false
+		return ErrInvalidCredentials
 	}
 
 	iterations, err := strconv.Atoi(parts[1])
 	if err != nil {
-		return false
+		return ErrInvalidCredentials
 	}
 
 	salt, err := base64.RawStdEncoding.DecodeString(parts[2])
 	if err != nil {
-		return false
+		return ErrInvalidCredentials
 	}
 
 	derived, err := base64.RawStdEncoding.DecodeString(parts[3])
 	if err != nil {
-		return false
+		return ErrInvalidCredentials
 	}
 
 	dk, err := pbkdf2.Key(sha256.New, password, salt, iterations, 32)
 	if err != nil {
-		return false
+		return ErrInvalidCredentials
 	}
 
-	return subtle.ConstantTimeCompare(dk, derived) == 1
+	if subtle.ConstantTimeCompare(dk, derived) != 1 {
+		return ErrInvalidCredentials
+	}
+	return nil
 }

--- a/tlsrouter.go
+++ b/tlsrouter.go
@@ -3,7 +3,10 @@ package tlsrouter
 import (
 	"bytes"
 	"context"
+	"crypto/hmac"
+	"crypto/rand"
 	"crypto/sha256"
+	"crypto/subtle"
 	"crypto/tls"
 	"encoding/hex"
 	"encoding/json"
@@ -222,6 +225,7 @@ type Backend struct {
 	ForceHTTP     bool               `json:"force_http,omitempty"`
 	ConnectTLS    bool               `json:"connect_tls"`
 	SkipTLSVerify bool               `json:"connect_insecure"`
+	AuthToken     string             `json:"auth_token,omitempty"`
 	// Healthy         *atomic.Bool       `json:"-"`
 	// ConnectSNI      string             `json:"connect_sni,omitempty"`
 	// ConnectALPNs    string             `json:"connect_alpn,omitempty"`
@@ -548,7 +552,7 @@ func NewListenConfig(conf Config) *ListenConfig {
 			alpn := snialpn.ALPN()
 			fmt.Fprintf(os.Stderr, "DEBUG: %s: incoming snialpn %s\n", domain, alpn)
 			if alpn == "h2" || alpn == "h3" || alpn == "http/1.1" || backend.ForceHTTP {
-				lc.setupHTTPReverseProxy(&backend)
+				lc.setupHTTPReverseProxy(domain, &backend, conf.TabVault)
 				m.Backends[beIndex] = backend
 			}
 		}
@@ -563,8 +567,15 @@ func NewListenConfig(conf Config) *ListenConfig {
 // backend.HTTPTunnel so HTTP-family traffic has X-Forwarded-* re-set from the
 // trusted inbound request (http.ReverseProxy.Rewrite strips them by design).
 // Callers must have already chosen an HTTP-family ALPN for the backend.
-func (lc *ListenConfig) setupHTTPReverseProxy(backend *Backend) {
+func (lc *ListenConfig) setupHTTPReverseProxy(domain string, backend *Backend, vault *tabvault.TabVault) {
 	backend.HTTPTunnel = tun.NewListener(lc.Context)
+	var authMissing bool
+	if backend.AuthToken != "" {
+		if vault == nil || vault.Get(backend.AuthToken) == "" {
+			authMissing = true
+			log.Printf("FATAL: auth token %q not found in vault for %s — blocking all traffic", backend.AuthToken, backend.Host)
+		}
+	}
 
 	target := &url.URL{
 		Scheme: "http",
@@ -633,9 +644,18 @@ func (lc *ListenConfig) setupHTTPReverseProxy(backend *Backend) {
 	}
 	proxy.Transport = transport
 
+	var handler http.Handler = proxy
+	if authMissing {
+		handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "503 Service Unavailable\n", http.StatusServiceUnavailable)
+		})
+	} else if backend.AuthToken != "" {
+		handler = newAuthGate(domain, vault, backend.AuthToken, proxy)
+	}
+
 	// TODO track these for shutdown (to call Shutdown() and Close() on each)
 	proxyServer := &http.Server{
-		Handler: proxy,
+		Handler: handler,
 		BaseContext: func(_ net.Listener) context.Context {
 			return lc.Context
 		},
@@ -644,6 +664,89 @@ func (lc *ListenConfig) setupHTTPReverseProxy(backend *Backend) {
 	go func() {
 		_ = proxyServer.Serve(backend.HTTPTunnel)
 	}()
+}
+
+const (
+	authHeaderName = "X-TLS-Router-Auth"
+	authCookieName = "tlsrouter_session"
+)
+
+var authHMACKey []byte
+
+func init() {
+	authHMACKey = make([]byte, 32)
+	if _, err := rand.Read(authHMACKey); err != nil {
+		panic("crypto/rand: " + err.Error())
+	}
+}
+
+func sessionMAC(domain string) string {
+	mac := hmac.New(sha256.New, authHMACKey)
+	mac.Write([]byte(domain))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+func newAuthGate(domain string, verifier BasicVerifier, tokenID string, next http.Handler) http.Handler {
+	expectedMAC := sessionMAC(domain)
+	authPrompt := fmt.Sprintf("Access to %s requires authentication.\n\n"+
+		"Enter %q as the username and your access token as the password.\n"+
+		"For automated access (no cookies), set the %s header.\n", domain, domain, authHeaderName)
+	wwwAuth := fmt.Sprintf(`Basic realm=%q`, domain)
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		if headerVal := r.Header.Get(authHeaderName); headerVal != "" {
+			if verifier.Verify(tokenID, headerVal) == nil {
+				r.Header.Del(authHeaderName)
+				next.ServeHTTP(w, r)
+				return
+			}
+			w.Header().Set("WWW-Authenticate", wwwAuth)
+			http.Error(w, "401 Unauthorized\n", http.StatusUnauthorized)
+			return
+		}
+
+		if cookie, err := r.Cookie(authCookieName); err == nil {
+			if subtle.ConstantTimeCompare([]byte(cookie.Value), []byte(expectedMAC)) == 1 {
+				next.ServeHTTP(w, r)
+				return
+			}
+			http.SetCookie(w, &http.Cookie{
+				Name:     authCookieName,
+				Value:    "",
+				Path:     "/",
+				MaxAge:   -1,
+				HttpOnly: true,
+				Secure:   true,
+			})
+			w.Header().Set("WWW-Authenticate", wwwAuth)
+			w.WriteHeader(http.StatusUnauthorized)
+			fmt.Fprintf(w, "Session expired. %s", authPrompt)
+			return
+		}
+
+		if _, password, ok := r.BasicAuth(); ok {
+			if verifier.Verify(tokenID, password) == nil {
+				http.SetCookie(w, &http.Cookie{
+					Name:     authCookieName,
+					Value:    expectedMAC,
+					Path:     "/",
+					HttpOnly: true,
+					Secure:   true,
+					SameSite: http.SameSiteLaxMode,
+				})
+				http.Redirect(w, r, r.URL.RequestURI(), http.StatusFound)
+				return
+			}
+			w.Header().Set("WWW-Authenticate", wwwAuth)
+			http.Error(w, "401 Unauthorized\n", http.StatusUnauthorized)
+			return
+		}
+
+		w.Header().Set("WWW-Authenticate", wwwAuth)
+		w.WriteHeader(http.StatusUnauthorized)
+		fmt.Fprint(w, authPrompt)
+	})
 }
 
 func rewriteHeaderHost(h http.Header, key, oldHost, newHost string) {


### PR DESCRIPTION
## Summary
- Add `auth` column to CSV config for per-backend authentication via vault secrets
- Auth gate middleware checks: header (`X-TLS-Router-Auth`) → cookie (`tlsrouter_session`) → basic auth → 401
- Supports both plaintext and PHC pbkdf2-sha256 secrets via `TabVault.Verify`
- **Fails closed**: missing vault secret → 503 for all traffic; stale cookie → cleared + 401
- All credential failures return 401 + `WWW-Authenticate` realm to re-prompt browsers
- Session cookies use HMAC-SHA256 keyed by the secret, scoped per domain
- `FieldsPerRecord = -1` for variable-length CSV rows (backwards compatible with configs missing the auth column)

## Test plan
- [x] No credentials → 401 Unauthorized
- [x] Wrong password (basic auth) → 401 Unauthorized (re-prompts browser)
- [x] Wrong header token → 401 Unauthorized
- [x] Correct password (PHC pbkdf2-sha256) via basic auth → 302 redirect with session cookie
- [x] Follow redirect → 200 with backend content
- [x] Valid session cookie only (no basic auth) → 200
- [x] Bad/stale session cookie → 401 (cookie cleared, re-prompts)
- [x] Correct password via `X-TLS-Router-Auth` header → 200
- [x] Non-protected endpoints unaffected → 200
- [x] Builds clean, no regressions