### PR TITLE
fix(cli): reduce default pbkdf2 iterations to 10000

### DIFF
--- a/cmd/tlsrouter/hashpassword.go
+++ b/cmd/tlsrouter/hashpassword.go
@@ -74,7 +74,7 @@ func runHashPassword() int {
 	salt := make([]byte, 16)
 	_, _ = rand.Read(salt)
 
-	iterations := 600000
+	iterations := 10000
 	dk, err := pbkdf2.Key(sha256.New, password, salt, iterations, 32)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)


### PR DESCRIPTION
## Summary
- Reduce default pbkdf2 iterations from 600,000 to 10,000
- 600k iterations took ~700ms per verify on the server; 10k is a better balance

## Test plan
- [x] hash-password output uses 10000 in the PHC string
- [x] Round-trip: hash then verify with tabvault succeeds