### PR TITLE
tracking: unified service map + IP filtering + conntracker

### DIFF
--- a/bin/tlsrouterjsontocsv/main.go
+++ b/bin/tlsrouterjsontocsv/main.go
@@ -13,6 +13,7 @@ type Backend struct {
 	Port          int    `json:"port"`
 	TerminateTLS  bool   `json:"terminate_tls"`
 	ConnectTLS    bool   `json:"connect_tls"`
+	RewriteHost   string `json:"rewrite_host"`
 	SkipTLSVerify bool   `json:"connect_insecure"`
 }
 
@@ -46,17 +47,17 @@ func main() {
 	var data Data
 	_ = json.Unmarshal(bytes, &data)
 
-	fmt.Println("app_slug\tdomain\talpn\tbackend_address\tbackend_port\tterminate_tls\tconnect_tls\tconnect_insecure")
+	fmt.Println("app_slug\tdomain\talpn\tbackend_address\tbackend_port\tterminate_tls\tconnect_tls\trewrite_host\tconnect_insecure")
 
 	for _, app := range data.Apps {
 		for _, service := range app.Services {
 			for _, domain := range service.Domains {
 				for _, alpn := range service.Alpns {
 					for _, backend := range service.Backends {
-						fmt.Printf("%s\t%s\t%s\t%s\t%d\t%v\t%v\t%v\n",
+						fmt.Printf("%s\t%s\t%s\t%s\t%d\t%v\t%v\t%v\t%v\n",
 							app.Slug, domain, alpn,
 							backend.Address, backend.Port,
-							backend.TerminateTLS, backend.ConnectTLS, backend.SkipTLSVerify)
+							backend.TerminateTLS, backend.ConnectTLS, backend.RewriteHost, backend.SkipTLSVerify)
 					}
 				}
 			}

--- a/cmd/tlsrouter/main.go
+++ b/cmd/tlsrouter/main.go
@@ -144,6 +144,12 @@ func main() {
 	}
 	mainFlags.StringVar(&vaultPath, "vault", defaultVaultPath, "Path to vault TSV (Tab CSV) file")
 
+	var ipWhitelistPath string
+	mainFlags.StringVar(&ipWhitelistPath, "ip-whitelist", "", "Path to IP whitelist CSV file (IPs/CIDRs allowed to connect)")
+
+	var ipBlacklistPath string
+	mainFlags.StringVar(&ipBlacklistPath, "ip-blacklist", "", "Path to IP blacklist data directory (git-managed, requires --ip-whitelist)")
+
 	// usage
 	mainFlags.Usage = func() {
 		printVersion()
@@ -238,6 +244,24 @@ func main() {
 	mux := http.NewServeMux()
 	setupRouter(conf, mux)
 	lc := tlsrouter.NewListenConfig(conf)
+
+	if ipBlacklistPath != "" && ipWhitelistPath == "" {
+		log.Fatal("--ip-blacklist requires --ip-whitelist (anti-lockout)")
+	}
+	if ipWhitelistPath != "" {
+		ipFilter, err := tlsrouter.NewIPFilter(lc.Context, ipWhitelistPath)
+		if err != nil {
+			log.Fatalf("ip-whitelist: %v", err)
+		}
+		lc.SetIPFilter(ipFilter)
+	}
+	if ipBlacklistPath != "" {
+		bl, err := tlsrouter.NewIPBlocklist(lc.Context, ipBlacklistPath)
+		if err != nil {
+			log.Fatalf("ip-blacklist: %v", err)
+		}
+		lc.SetIPBlocklist(bl)
+	}
 
 	var wg sync.WaitGroup
 	addr := fmt.Sprintf("%s:%d", bind, port)

--- a/configfile.go
+++ b/configfile.go
@@ -199,6 +199,7 @@ var expectedHeaders = []string{
 	"backend_port",
 	"terminate_tls",
 	"connect_tls",
+	"rewrite_host",
 	"skip_tls_verify",
 	"auth",
 	"allowed_client_hostnames",
@@ -270,6 +271,10 @@ func ReadCSVToConfig(r *csv.Reader) (*Config, error) {
 		connectTLS := false
 		if i, ok := headerIndices["connect_tls"]; ok && i < len(record) && strings.ToLower(record[i]) == "true" {
 			connectTLS = true
+		}
+		rewriteHost := ""
+		if i, ok := headerIndices["rewrite_host"]; ok && i < len(record) {
+			rewriteHost = record[i]
 		}
 		connectInsecure := false
 		if i, ok := headerIndices["skip_tls_verify"]; ok && i < len(record) && strings.ToLower(record[i]) == "true" {
@@ -395,6 +400,7 @@ func ReadCSVToConfig(r *csv.Reader) (*Config, error) {
 				Port:          port,
 				TerminateTLS:  terminateTLS,
 				ConnectTLS:    connectTLS,
+				RewriteHost:   rewriteHost,
 				SkipTLSVerify: connectInsecure,
 				AuthToken:     authToken,
 			}
@@ -435,6 +441,7 @@ type CSVRecord struct {
 	BackendPort            uint16
 	TerminateTLS           bool
 	ConnectTLS             bool
+	RewriteHost            string
 	SkipTLSVerify          bool
 	Auth                   string
 	AllowedClientHostnames string
@@ -467,6 +474,7 @@ func (c *Config) ToRecords() ([]CSVRecord, error) {
 							BackendPort:            backend.Port,
 							TerminateTLS:           backend.TerminateTLS,
 							ConnectTLS:             backend.ConnectTLS,
+							RewriteHost:            backend.RewriteHost,
 							SkipTLSVerify:          backend.SkipTLSVerify,
 							Auth:                   backend.AuthToken,
 							AllowedClientHostnames: strings.Join(service.AllowedClientHostnames, ";"),
@@ -506,6 +514,9 @@ func (c *Config) ToRecords() ([]CSVRecord, error) {
 		if a.ConnectTLS != b.ConnectTLS {
 			return strings.Compare(fmt.Sprintf("%t", a.ConnectTLS), fmt.Sprintf("%t", b.ConnectTLS))
 		}
+		if a.RewriteHost != b.RewriteHost {
+			return strings.Compare(a.RewriteHost, b.RewriteHost)
+		}
 		if a.SkipTLSVerify != b.SkipTLSVerify {
 			return strings.Compare(fmt.Sprintf("%t", a.SkipTLSVerify), fmt.Sprintf("%t", b.SkipTLSVerify))
 		}
@@ -535,6 +546,7 @@ func RecordsToCSV(csvw *csv.Writer, records []CSVRecord) error {
 			fmt.Sprintf("%d", record.BackendPort),
 			fmt.Sprintf("%t", record.TerminateTLS),
 			fmt.Sprintf("%t", record.ConnectTLS),
+			record.RewriteHost,
 			fmt.Sprintf("%t", record.SkipTLSVerify),
 			record.Auth,
 			record.AllowedClientHostnames,

--- a/configfile.go
+++ b/configfile.go
@@ -11,11 +11,12 @@ import (
 	"strconv"
 	"strings"
 	"sync/atomic"
+	"time"
 )
 
-func NormalizeConfig(conf *Config) (map[string][]string, map[SNIALPN]*ConfigService) {
+func NormalizeConfig(conf *Config) (map[string][]string, map[SNIALPN]*dnsCacheEntry) {
 	domainALPNMatchers := map[string][]string{}
-	snialpnMatchers := map[SNIALPN]*ConfigService{}
+	snialpnMatchers := map[SNIALPN]*dnsCacheEntry{}
 
 	for i, app := range conf.Apps {
 		for i, srv := range app.Services {
@@ -65,18 +66,21 @@ func NormalizeConfig(conf *Config) (map[string][]string, map[SNIALPN]*ConfigServ
 
 					snialpn := NewSNIALPN(domain, alpn)
 
-					tlsMatch := snialpnMatchers[snialpn]
-					if tlsMatch == nil {
-						tlsMatch = &ConfigService{
-							CurrentBackend: new(atomic.Uint32),
+					entry := snialpnMatchers[snialpn]
+					if entry == nil {
+						entry = &dnsCacheEntry{
+							service: &ConfigService{
+								CurrentBackend: new(atomic.Uint32),
+							},
+							staleAt:   time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
+							expiredAt: time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
 						}
-						snialpnMatchers[snialpn] = tlsMatch
+						snialpnMatchers[snialpn] = entry
 					}
 
 					for _, b := range srv.Backends {
-						// fmt.Printf("\n\nDEBUG: m.Backends[i] %#v\n", b)
 						b.Host = fmt.Sprintf("%s:%d", b.Address, b.Port)
-						tlsMatch.Backends = append(tlsMatch.Backends, b)
+						entry.service.Backends = append(entry.service.Backends, b)
 					}
 				}
 			}

--- a/conntracker.go
+++ b/conntracker.go
@@ -1,0 +1,169 @@
+package tlsrouter
+
+import (
+	"encoding/csv"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+type connRecord struct {
+	IP       string
+	LastSeen time.Time
+	Count    uint64
+	BytesIn  uint64
+	BytesOut uint64
+}
+
+type connTracker struct {
+	mu      sync.Mutex
+	records map[string]*connRecord // keyed by "domain\tip"
+	dirty   bool
+	stop    chan struct{}
+}
+
+func newConnTracker() *connTracker {
+	ct := &connTracker{
+		records: make(map[string]*connRecord),
+		stop:    make(chan struct{}),
+	}
+	ct.load()
+	go ct.flushLoop()
+	return ct
+}
+
+func (ct *connTracker) Track(domain, ip string, bytesIn, bytesOut uint64) {
+	key := domain + "\t" + ip
+	ct.mu.Lock()
+	rec, ok := ct.records[key]
+	if !ok {
+		rec = &connRecord{IP: ip}
+		ct.records[key] = rec
+	}
+	rec.LastSeen = time.Now()
+	rec.Count++
+	rec.BytesIn += bytesIn
+	rec.BytesOut += bytesOut
+	ct.dirty = true
+	ct.mu.Unlock()
+}
+
+func (ct *connTracker) Shutdown() {
+	close(ct.stop)
+	ct.flush()
+}
+
+func (ct *connTracker) flushLoop() {
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			ct.flush()
+		case <-ct.stop:
+			return
+		}
+	}
+}
+
+func (ct *connTracker) flush() {
+	ct.mu.Lock()
+	if !ct.dirty {
+		ct.mu.Unlock()
+		return
+	}
+
+	var buf strings.Builder
+	w := csv.NewWriter(&buf)
+	w.Comma = '\t'
+	_ = w.Write([]string{"domain", "ip", "last_seen", "count", "bytes_in", "bytes_out"})
+	for key, rec := range ct.records {
+		domain, ip, _ := strings.Cut(key, "\t")
+		_ = w.Write([]string{
+			domain,
+			ip,
+			rec.LastSeen.UTC().Format(time.RFC3339),
+			strconv.FormatUint(rec.Count, 10),
+			strconv.FormatUint(rec.BytesIn, 10),
+			strconv.FormatUint(rec.BytesOut, 10),
+		})
+	}
+	w.Flush()
+	ct.dirty = false
+	ct.mu.Unlock()
+
+	path := connTrackerPath()
+	_ = os.MkdirAll(filepath.Dir(path), 0o700)
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte(buf.String()), 0o644); err != nil {
+		return
+	}
+	_ = os.Remove(path + ".bak")
+	if _, err := os.Stat(path); err == nil {
+		if err := os.Rename(path, path+".bak"); err != nil {
+			fmt.Fprintf(os.Stderr, "WARN: conntracker: failed to backup %s: %v\n", path, err)
+			return
+		}
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		fmt.Fprintf(os.Stderr, "WARN: conntracker: failed to rename %s: %v\n", tmp, err)
+	}
+}
+
+func (ct *connTracker) load() {
+	f, err := os.Open(connTrackerPath())
+	if err != nil {
+		return
+	}
+	defer f.Close()
+
+	r := csv.NewReader(f)
+	r.Comma = '\t'
+	r.Comment = '#'
+
+	records, err := r.ReadAll()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "WARN: conntracker: failed to read %s: %v\n", connTrackerPath(), err)
+		return
+	}
+
+	for _, fields := range records {
+		if len(fields) < 4 {
+			continue
+		}
+		if fields[0] == "domain" {
+			continue
+		}
+		domain := fields[0]
+		ip := fields[1]
+		t, err := time.Parse(time.RFC3339, fields[2])
+		if err != nil {
+			continue
+		}
+		count, err := strconv.ParseUint(fields[3], 10, 64)
+		if err != nil {
+			continue
+		}
+		var bytesIn, bytesOut uint64
+		if len(fields) >= 6 {
+			bytesIn, _ = strconv.ParseUint(fields[4], 10, 64)
+			bytesOut, _ = strconv.ParseUint(fields[5], 10, 64)
+		}
+		key := domain + "\t" + ip
+		ct.records[key] = &connRecord{
+			IP:       ip,
+			LastSeen: t,
+			Count:    count,
+			BytesIn:  bytesIn,
+			BytesOut: bytesOut,
+		}
+	}
+}
+
+func connTrackerPath() string {
+	return filepath.Join(certmagicDataDir(), "connections.tsv")
+}

--- a/dynamic-config.go
+++ b/dynamic-config.go
@@ -155,8 +155,8 @@ func (lc *ListenConfig) cacheService(snialpn SNIALPN, domain string, service *Co
 		expiredAt: now.Add(ttlDur + staleTTL),
 	}
 
-	lc.slowConfigMu.Lock()
-	lc.slowConfigBySNIALPN[snialpn] = entry
+	lc.serviceMu.Lock()
+	lc.serviceBySNIALPN[snialpn] = entry
 	if route.Terminate {
 		lc.slowCertmagicConfMap[domain] = struct{}{}
 	} else {
@@ -165,7 +165,7 @@ func (lc *ListenConfig) cacheService(snialpn SNIALPN, domain string, service *Co
 			lc.slowACMETLS1ByDomain[domain] = &backend
 		}
 	}
-	lc.slowConfigMu.Unlock()
+	lc.serviceMu.Unlock()
 
 	if route.Terminate {
 		if err := lc.certmagicTLSALPNOnly.ManageSync(lc.Context, []string{domain}); err != nil {
@@ -209,20 +209,12 @@ func getAllowedIP(
 		}
 	}
 
-	var selectedALPN string
-	var selectedPort uint16
-	var match bool
-	for _, ipNet := range conf.Networks {
-		if ipNet.Contains(ip) {
-			match = true
-			fmt.Fprintf(os.Stderr, "DEBUG: %s: found matching network %q\n", domain, ipNet.String())
-			break
-		}
-		fmt.Fprintf(os.Stderr, "DEBUG: %s: IP %q is not in network %q\n", domain, ip.String(), ipNet.String())
-	}
-	if !match {
+	if !conf.IsAllowedIP(ip) {
 		return nil, errTryNext
 	}
+
+	var selectedALPN string
+	var selectedPort uint16
 
 	if terminate {
 		for _, alpn := range alpns {
@@ -316,14 +308,7 @@ func getAllowedSrv(
 			return
 		}
 
-		allowed := false
-		for _, ipNet := range conf.Networks {
-			if ipNet.Contains(ip) {
-				allowed = true
-				break
-			}
-		}
-		if !allowed {
+		if !conf.IsAllowedIP(ip) {
 			return
 		}
 
@@ -417,7 +402,7 @@ func findSrvForALPN(
 			Weight:   srv.Weight,
 		}
 		dbg("DEBUG: %s: %s %s: SRV record %#v", domain, service, proto, srvCompat)
-		route, checkErr := checkSRV(conf.IPDomains, conf.Networks, srvCompat, domain, alpn)
+		route, checkErr := checkSRV(conf, srvCompat, domain, alpn)
 		dbg("DEBUG: %s: %s %s: SRV check %v, %v", domain, service, proto, route, checkErr)
 		if checkErr != nil {
 			continue
@@ -444,8 +429,7 @@ func findSrvForALPN(
 }
 
 func checkSRV(
-	ipDomains []string,
-	networks []net.IPNet,
+	conf *Config,
 	srv *net.SRV,
 	domain string,
 	alpn string,
@@ -475,7 +459,7 @@ func checkSRV(
 	//   label = "net."
 	var suffix string
 	var ok bool
-	for _, ipDomain := range ipDomains {
+	for _, ipDomain := range conf.IPDomains {
 		suffix, ok = strings.CutPrefix(targetParts[1], ipDomain)
 		if ok {
 			break
@@ -514,14 +498,7 @@ func checkSRV(
 		return nil, errors.New("unsupported ALPN or port mismatch")
 	}
 
-	allowed := false
-	for _, ipNet := range networks {
-		if ipNet.Contains(ip) {
-			allowed = true
-			break
-		}
-	}
-	if !allowed {
+	if !conf.IsAllowedIP(ip) {
 		return nil, ErrUnknownNetwork
 	}
 

--- a/dynamic-config.go
+++ b/dynamic-config.go
@@ -124,6 +124,7 @@ func (lc *ListenConfig) buildService(conf *Config, domain string, route *dnsRout
 		Port:          route.Port,
 		TerminateTLS:  route.Terminate,
 		ConnectTLS:    false,
+		RewriteHost:   "",
 		SkipTLSVerify: false,
 	}
 

--- a/dynamic-config.go
+++ b/dynamic-config.go
@@ -169,11 +169,29 @@ func (lc *ListenConfig) cacheService(snialpn SNIALPN, domain string, service *Co
 	lc.serviceMu.Unlock()
 
 	if route.Terminate {
+		if err := checkBackendReachable(route.IP.String(), route.Port); err != nil {
+			return fmt.Errorf("backend unreachable for %s, skipping ACME: %w", domain, err)
+		}
 		if err := lc.certmagicTLSALPNOnly.ManageSync(lc.Context, []string{domain}); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func checkBackendReachable(ip string, port uint16) error {
+	targets := []string{net.JoinHostPort(ip, strconv.Itoa(int(port)))}
+	if port != 22 {
+		targets = append(targets, net.JoinHostPort(ip, "22"))
+	}
+	for _, addr := range targets {
+		conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
+		if err == nil {
+			conn.Close()
+			return nil
+		}
+	}
+	return fmt.Errorf("tcp dial failed for %s on port %d and ssh", ip, port)
 }
 
 func getAllowedIP(

--- a/dynamic-config.go
+++ b/dynamic-config.go
@@ -184,14 +184,27 @@ func checkBackendReachable(ip string, port uint16) error {
 	if port != 22 {
 		targets = append(targets, net.JoinHostPort(ip, "22"))
 	}
+
+	success := make(chan struct{}, 1)
 	for _, addr := range targets {
-		conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
-		if err == nil {
-			conn.Close()
-			return nil
-		}
+		go func() {
+			conn, err := net.DialTimeout("tcp", addr, 750*time.Millisecond)
+			if err == nil {
+				conn.Close()
+				select {
+				case success <- struct{}{}:
+				default:
+				}
+			}
+		}()
 	}
-	return fmt.Errorf("tcp dial failed for %s on port %d and ssh", ip, port)
+
+	select {
+	case <-success:
+		return nil
+	case <-time.After(750 * time.Millisecond):
+		return fmt.Errorf("tcp dial failed for %s on port %d and ssh", ip, port)
+	}
 }
 
 func getAllowedIP(

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bnnanet/tlsrouter
 
-go 1.25.6
+go 1.26.0
 
 tool github.com/therootcompany/golib/io/transform/gsheet2csv/cmd/gsheet2csv
 
@@ -20,6 +20,8 @@ require (
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/libdns/libdns v1.1.1 // indirect
 	github.com/therootcompany/golib/io/transform/gsheet2csv v1.0.3 // indirect
+	github.com/therootcompany/golib/net/gitshallow v0.9.0 // indirect
+	github.com/therootcompany/golib/net/ipcohort v0.9.0 // indirect
 	github.com/zeebo/blake3 v0.2.4 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,10 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/therootcompany/golib/io/transform/gsheet2csv v1.0.3 h1:220hPRUieZtIc6cWlAwKbNzOJxAbscsJy83+2qIai2Q=
 github.com/therootcompany/golib/io/transform/gsheet2csv v1.0.3/go.mod h1:/GwkISS5hHJPhYIQ9B92zAfo56VuEP2NW2N10InCcWs=
+github.com/therootcompany/golib/net/gitshallow v0.9.0 h1:JNDqTD8HG4TYTmUc18Vo2MJ6tJ/12pcQo+8qG9rdV9k=
+github.com/therootcompany/golib/net/gitshallow v0.9.0/go.mod h1:S/3OK7wMOqJJjP79U9Qw/l3jjEyrb/zsjJ8HAPAX/Fc=
+github.com/therootcompany/golib/net/ipcohort v0.9.0 h1:j3AaoW2u4XQJz1ya6fixv3pb3KgxIpZV8t0082/kS3E=
+github.com/therootcompany/golib/net/ipcohort v0.9.0/go.mod h1:Ljcnt2xOryVDGIVV5Kzt5hj2LhW4lBAWo5OeeVYU9ys=
 github.com/zeebo/assert v1.1.0 h1:hU1L1vLTHsnO8x8c9KAR5GmM5QscxHg5RNU5z5qbUWY=
 github.com/zeebo/assert v1.1.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/blake3 v0.2.4 h1:KYQPkhpRtcqh0ssGYcKLG1JYvddkEA8QwCM/yBqhaZI=

--- a/ipblocklist.go
+++ b/ipblocklist.go
@@ -1,0 +1,108 @@
+package tlsrouter
+
+import (
+	"context"
+	"fmt"
+	"net/netip"
+	"os"
+	"sync/atomic"
+	"time"
+
+	"github.com/therootcompany/golib/net/gitshallow"
+	"github.com/therootcompany/golib/net/ipcohort"
+)
+
+const (
+	blocklistRepoURL  = "https://github.com/bitwire-it/ipblocklist.git"
+	blocklistInterval = 47 * time.Minute
+)
+
+type IPBlocklist struct {
+	repo     *gitshallow.Repo
+	inbound  atomic.Pointer[ipcohort.Cohort]
+	outbound atomic.Pointer[ipcohort.Cohort]
+}
+
+func NewIPBlocklist(ctx context.Context, dataPath string) (*IPBlocklist, error) {
+	bl := &IPBlocklist{
+		repo: gitshallow.New(
+			blocklistRepoURL,
+			dataPath,
+			1,
+			"",
+		),
+	}
+
+	if err := bl.reload(ctx); err != nil {
+		return nil, fmt.Errorf("ipblocklist: initial load: %w", err)
+	}
+
+	go bl.refreshLoop(ctx)
+
+	return bl, nil
+}
+
+func (bl *IPBlocklist) reload(ctx context.Context) error {
+	updated, err := bl.repo.Fetch(ctx)
+	if err != nil {
+		return err
+	}
+	if !updated && bl.inbound.Load() != nil {
+		return nil
+	}
+
+	in, err := ipcohort.LoadFiles(
+		bl.repo.FilePath("tables/inbound/single_ips.txt"),
+		bl.repo.FilePath("tables/inbound/networks.txt"),
+	)
+	if err != nil {
+		return fmt.Errorf("load inbound: %w", err)
+	}
+
+	out, err := ipcohort.LoadFiles(
+		bl.repo.FilePath("tables/outbound/single_ips.txt"),
+		bl.repo.FilePath("tables/outbound/networks.txt"),
+	)
+	if err != nil {
+		return fmt.Errorf("load outbound: %w", err)
+	}
+
+	bl.inbound.Store(in)
+	bl.outbound.Store(out)
+
+	fmt.Fprintf(os.Stderr, "INFO: ipblocklist: loaded inbound=%d outbound=%d entries\n",
+		in.Size(), out.Size())
+	return nil
+}
+
+func (bl *IPBlocklist) refreshLoop(ctx context.Context) {
+	ticker := time.NewTicker(blocklistInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := bl.reload(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "WARN: ipblocklist: reload: %v\n", err)
+			}
+		}
+	}
+}
+
+func (bl *IPBlocklist) IsBlockedInbound(addr netip.Addr) bool {
+	cohort := bl.inbound.Load()
+	if cohort == nil {
+		return false
+	}
+	return cohort.ContainsAddr(addr)
+}
+
+func (bl *IPBlocklist) IsBlockedOutbound(addr netip.Addr) bool {
+	cohort := bl.outbound.Load()
+	if cohort == nil {
+		return false
+	}
+	return cohort.ContainsAddr(addr)
+}

--- a/ipfilter.go
+++ b/ipfilter.go
@@ -1,0 +1,193 @@
+package tlsrouter
+
+import (
+	"context"
+	"encoding/csv"
+	"fmt"
+	"io"
+	"net"
+	"net/netip"
+	"os"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/therootcompany/golib/net/ipcohort"
+)
+
+const whitelistRefreshInterval = 5 * time.Minute
+
+type whitelistEntry struct {
+	Raw   string
+	Label string
+}
+
+type IPFilter struct {
+	staticPrefixes []string
+	domains        []whitelistEntry
+	resolved       atomic.Pointer[map[string][]string] // domain → resolved IPs from last success
+	cohort         atomic.Pointer[ipcohort.Cohort]
+}
+
+func NewIPFilter(ctx context.Context, whitelistPath string) (*IPFilter, error) {
+	if whitelistPath == "" {
+		return nil, nil
+	}
+
+	staticPrefixes, domains, err := parseWhitelist(whitelistPath)
+	if err != nil {
+		return nil, fmt.Errorf("whitelist %q: %w", whitelistPath, err)
+	}
+
+	f := &IPFilter{
+		staticPrefixes: staticPrefixes,
+		domains:        domains,
+	}
+
+	// Initialize resolved map
+	emptyResolved := make(map[string][]string)
+	f.resolved.Store(&emptyResolved)
+
+	// Initial resolve (blocking)
+	f.resolveDomains(ctx)
+
+	// Rebuild cohort from static + resolved
+	f.rebuildCohort()
+
+	cohort := f.cohort.Load()
+	fmt.Fprintf(os.Stderr, "INFO: ip-whitelist: %d static + %d domains (%d total entries) from %s\n",
+		len(staticPrefixes), len(domains), cohort.Size(), whitelistPath)
+
+	go f.refreshLoop(ctx)
+
+	return f, nil
+}
+
+func (f *IPFilter) IsAllowed(addr netip.Addr) bool {
+	cohort := f.cohort.Load()
+	if cohort == nil {
+		return false
+	}
+	return cohort.ContainsAddr(addr)
+}
+
+func (f *IPFilter) refreshLoop(ctx context.Context) {
+	ticker := time.NewTicker(whitelistRefreshInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			f.resolveDomains(ctx)
+			f.rebuildCohort()
+		}
+	}
+}
+
+func (f *IPFilter) resolveDomains(ctx context.Context) {
+	if len(f.domains) == 0 {
+		return
+	}
+
+	prev := *f.resolved.Load()
+	next := make(map[string][]string, len(f.domains))
+
+	resolver := &net.Resolver{}
+	for _, entry := range f.domains {
+		resolveCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		addrs, err := resolver.LookupHost(resolveCtx, entry.Raw)
+		cancel()
+
+		if err != nil || len(addrs) == 0 {
+			// Keep previous resolution on failure
+			if old, ok := prev[entry.Raw]; ok {
+				next[entry.Raw] = old
+				fmt.Fprintf(os.Stderr, "WARN: ip-whitelist: %s: resolve failed, keeping %d prior IPs: %v\n",
+					entry.Raw, len(old), err)
+			} else {
+				fmt.Fprintf(os.Stderr, "WARN: ip-whitelist: %s: resolve failed (no prior data): %v\n",
+					entry.Raw, err)
+			}
+			continue
+		}
+
+		next[entry.Raw] = addrs
+	}
+
+	f.resolved.Store(&next)
+}
+
+func (f *IPFilter) rebuildCohort() {
+	var all []string
+	all = append(all, f.staticPrefixes...)
+
+	resolved := *f.resolved.Load()
+	for _, addrs := range resolved {
+		for _, addr := range addrs {
+			all = append(all, addr+"/32")
+		}
+	}
+
+	cohort, err := ipcohort.Parse(all)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "WARN: ip-whitelist: rebuild: %v\n", err)
+	}
+	if cohort != nil {
+		f.cohort.Store(cohort)
+	}
+}
+
+func parseWhitelist(path string) (staticPrefixes []string, domains []whitelistEntry, err error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer func() { _ = file.Close() }()
+
+	r := csv.NewReader(file)
+	r.FieldsPerRecord = -1
+	r.Comment = '#'
+	if strings.HasSuffix(path, ".tsv") {
+		r.Comma = '\t'
+	}
+
+	for {
+		record, readErr := r.Read()
+		if readErr == io.EOF {
+			break
+		}
+		if readErr != nil {
+			return nil, nil, fmt.Errorf("csv read: %w", readErr)
+		}
+		if len(record) == 0 {
+			continue
+		}
+
+		raw := strings.TrimSpace(record[0])
+		if raw == "" {
+			continue
+		}
+
+		var label string
+		if len(record) > 1 {
+			label = strings.TrimSpace(record[1])
+		}
+
+		// Try parsing as IP or CIDR
+		if _, err := netip.ParseAddr(raw); err == nil {
+			staticPrefixes = append(staticPrefixes, raw+"/32")
+			continue
+		}
+		if _, err := netip.ParsePrefix(raw); err == nil {
+			staticPrefixes = append(staticPrefixes, raw)
+			continue
+		}
+
+		// Not an IP — treat as domain
+		domains = append(domains, whitelistEntry{Raw: raw, Label: label})
+	}
+
+	return staticPrefixes, domains, nil
+}

--- a/tlsrouter.go
+++ b/tlsrouter.go
@@ -17,6 +17,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httputil"
+	"net/netip"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -291,10 +292,20 @@ type ListenConfig struct {
 	adminServer           *http.Server
 	netLn                 net.Listener
 	dns                   *dnsresolver.Resolver
+	blocklist             *IPBlocklist
+	ipFilter              *IPFilter
 	slowCertmagicConfMap  map[string]struct{}
 	slowACMETLS1ByDomain  map[string]*Backend
 	serviceMu             sync.RWMutex
 	resolveGroup          singleflight.Group
+}
+
+func (lc *ListenConfig) SetIPFilter(f *IPFilter) {
+	lc.ipFilter = f
+}
+
+func (lc *ListenConfig) SetIPBlocklist(bl *IPBlocklist) {
+	lc.blocklist = bl
 }
 
 // TODO move to *Listener
@@ -947,6 +958,16 @@ func (lc *ListenConfig) ListenAndProxy(addr string, mux *http.ServeMux) error {
 		select {
 		case conn := <-ch:
 			fmt.Fprintf(os.Stderr, "\nDEBUG: (new): accepted %s\n", conn.RemoteAddr())
+			peer, parseErr := netip.ParseAddrPort(conn.RemoteAddr().String())
+			if parseErr == nil {
+				peerAddr := peer.Addr()
+				whitelisted := lc.ipFilter != nil && lc.ipFilter.IsAllowed(peerAddr)
+				if !whitelisted && lc.blocklist != nil && lc.blocklist.IsBlockedInbound(peerAddr) {
+					fmt.Fprintf(os.Stderr, "INFO: rejected %s (blacklisted)\n", peerAddr)
+					_ = conn.Close()
+					continue
+				}
+			}
 			go func() {
 				_, _, err = lc.proxy(conn)
 				if err != nil {

--- a/tlsrouter.go
+++ b/tlsrouter.go
@@ -236,6 +236,7 @@ type Backend struct {
 	TerminateTLS  bool               `json:"terminate_tls"`
 	ForceHTTP     bool               `json:"force_http,omitempty"`
 	ConnectTLS    bool               `json:"connect_tls"`
+	RewriteHost   string             `json:"rewrite_host,omitempty"`
 	SkipTLSVerify bool               `json:"connect_insecure"`
 	AuthToken     string             `json:"auth_token,omitempty"`
 	// Healthy         *atomic.Bool       `json:"-"`
@@ -611,12 +612,18 @@ func (lc *ListenConfig) setupHTTPReverseProxy(domain string, backend *Backend, v
 	proxy := &httputil.ReverseProxy{
 		Rewrite: func(r *httputil.ProxyRequest) {
 			r.SetURL(target)
-			if backend.ConnectTLS {
+			switch strings.ToLower(backend.RewriteHost) {
+			case "", "false":
+				r.Out.Host = r.In.Host
+			case "true":
 				inHost := r.In.Host
 				rewriteHeaderHost(r.Out.Header, "Referer", inHost, target.Host)
 				rewriteHeaderHost(r.Out.Header, "Origin", inHost, target.Host)
-			} else {
-				r.Out.Host = r.In.Host // preserve original Host for plaintext backends
+			default:
+				inHost := r.In.Host
+				r.Out.Host = backend.RewriteHost
+				rewriteHeaderHost(r.Out.Header, "Referer", inHost, backend.RewriteHost)
+				rewriteHeaderHost(r.Out.Header, "Origin", inHost, backend.RewriteHost)
 			}
 			r.Out.Header.Del("X-Real-IP") // not auto-stripped
 			// We are the trust boundary: r.In.RemoteAddr is the real

--- a/tlsrouter.go
+++ b/tlsrouter.go
@@ -299,6 +299,7 @@ type ListenConfig struct {
 	slowACMETLS1ByDomain  map[string]*Backend
 	serviceMu             sync.RWMutex
 	resolveGroup          singleflight.Group
+	connTracker           *connTracker
 }
 
 func (lc *ListenConfig) SetIPFilter(f *IPFilter) {
@@ -314,6 +315,7 @@ func (lc *ListenConfig) Shutdown(ctx context.Context) {
 	_ = lc.netLn.Close()
 	// TODO create a context with a 5 second timeout and
 	_ = lc.adminServer.Shutdown(ctx)
+	lc.connTracker.Shutdown()
 	lc.done <- ctx
 }
 
@@ -360,6 +362,7 @@ func NewListenConfig(conf Config) *ListenConfig {
 		alpnsByDomain:         domainMatchers,
 		serviceBySNIALPN:      snialpnMatchers,
 		dns:                   dnsresolver.New(),
+		connTracker:           newConnTracker(),
 		slowACMETLS1ByDomain:  make(map[string]*Backend),
 		Context:               ctx,
 		Close:                 cancel,
@@ -1272,6 +1275,9 @@ func (lc *ListenConfig) proxy(conn net.Conn) (r int64, w int64, retErr error) {
 		fmt.Fprintf(os.Stderr, "DEBUG: %s: HANDLED > Bad Gateway (Terminated)\n", snialpn)
 	}
 	fmt.Fprintf(os.Stderr, "DEBUG: %s: CLOSED\n", snialpn)
+	if backend != nil {
+		lc.connTracker.Track(snialpn.SNI(), backend.Address, wconn.BytesRead.Load(), wconn.BytesWritten.Load())
+	}
 	return int64(wconn.BytesRead.Load()), int64(wconn.BytesWritten.Load()), retErr
 }
 

--- a/tlsrouter.go
+++ b/tlsrouter.go
@@ -101,6 +101,15 @@ func (c *Config) ShortSHA2() string {
 	return "h" + hex.EncodeToString(h[:4])[:7]
 }
 
+func (c *Config) IsAllowedIP(ip net.IP) bool {
+	for _, ipNet := range c.Networks {
+		if ipNet.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
 func (c *Config) SetSigChan(sigChan chan os.Signal) {
 	if c.sigChan != nil {
 		panic(errors.New("'sigChan' can only be set once"))
@@ -268,7 +277,7 @@ type ListenConfig struct {
 	Conns                 sync.Map
 	TLSMismatches         sync.Map
 	alpnsByDomain         map[string][]string
-	configBySNIALPN       map[SNIALPN]*ConfigService
+	serviceBySNIALPN      map[SNIALPN]*dnsCacheEntry
 	Context               context.Context
 	ACMEDirectoryEndpoint string
 	issuerConfMap         map[string]*ACMEDNS
@@ -284,8 +293,7 @@ type ListenConfig struct {
 	dns                   *dnsresolver.Resolver
 	slowCertmagicConfMap  map[string]struct{}
 	slowACMETLS1ByDomain  map[string]*Backend
-	slowConfigBySNIALPN   map[SNIALPN]*dnsCacheEntry
-	slowConfigMu          sync.RWMutex
+	serviceMu             sync.RWMutex
 	resolveGroup          singleflight.Group
 }
 
@@ -311,9 +319,9 @@ func NewListenConfig(conf Config) *ListenConfig {
 		GetConfigForCert: func(cert certmagic.Certificate) (*certmagic.Config, error) {
 			magic, exists := lc.certmagicConfMap[cert.Names[0]] // len(Names) >= 0 is guaranteed
 			if !exists {
-				lc.slowConfigMu.RLock()
+				lc.serviceMu.RLock()
 				_, exists = lc.slowCertmagicConfMap[cert.Names[0]]
-				lc.slowConfigMu.RUnlock()
+				lc.serviceMu.RUnlock()
 
 				if !exists {
 					return nil, fmt.Errorf("impossible error: pre-configured domain %q is no longer configured", strings.Join(cert.Names, ", "))
@@ -338,9 +346,8 @@ func NewListenConfig(conf Config) *ListenConfig {
 		Conns:                 sync.Map{},
 		TLSMismatches:         sync.Map{},
 		alpnsByDomain:         domainMatchers,
-		configBySNIALPN:       snialpnMatchers,
+		serviceBySNIALPN:      snialpnMatchers,
 		dns:                   dnsresolver.New(),
-		slowConfigBySNIALPN:   make(map[SNIALPN]*dnsCacheEntry),
 		slowACMETLS1ByDomain:  make(map[string]*Backend),
 		Context:               ctx,
 		Close:                 cancel,
@@ -349,7 +356,7 @@ func NewListenConfig(conf Config) *ListenConfig {
 		certmagicTLSALPNOnly:  nil,
 		certmagicConfMap:      make(map[string]*certmagic.Config),
 		slowCertmagicConfMap:  make(map[string]struct{}),
-		slowConfigMu:          sync.RWMutex{},
+		serviceMu:             sync.RWMutex{},
 		certmagicStorage:      certmagicStorage,
 		certmagicCache:        certmagicCache,
 		done:                  make(chan context.Context),
@@ -537,8 +544,8 @@ func NewListenConfig(conf Config) *ListenConfig {
 	// 	fmt.Fprintf(os.Stderr, "warning: ToS has not been agreed to\n")
 	// }
 
-	for snialpn, m := range snialpnMatchers {
-		for beIndex, backend := range m.Backends {
+	for snialpn, entry := range snialpnMatchers {
+		for beIndex, backend := range entry.service.Backends {
 			if !backend.TerminateTLS {
 				continue
 			}
@@ -558,7 +565,7 @@ func NewListenConfig(conf Config) *ListenConfig {
 			fmt.Fprintf(os.Stderr, "DEBUG: %s: incoming snialpn %s\n", domain, alpn)
 			if alpn == "h2" || alpn == "h3" || alpn == "http/1.1" || backend.ForceHTTP {
 				lc.setupHTTPReverseProxy(domain, &backend, conf.TabVault)
-				m.Backends[beIndex] = backend
+				entry.service.Backends[beIndex] = backend
 			}
 		}
 	}
@@ -997,14 +1004,14 @@ func (lc *ListenConfig) proxy(conn net.Conn) (r int64, w int64, retErr error) {
 				// note: certmagicConfMap only holds backends that terminate
 				magic := lc.certmagicConfMap[domain]
 				if magic == nil {
-					lc.slowConfigMu.RLock()
+					lc.serviceMu.RLock()
 					_, ok := lc.slowCertmagicConfMap[domain]
 					if ok {
 						magic = lc.certmagicTLSALPNOnly
 					} else {
 						backend = lc.slowACMETLS1ByDomain[domain]
 					}
-					lc.slowConfigMu.RUnlock()
+					lc.serviceMu.RUnlock()
 					if backend != nil {
 						var err error
 						if beConn, err = getBackendConn(lc.Context, backend.Host); err != nil {
@@ -1023,69 +1030,58 @@ func (lc *ListenConfig) proxy(conn net.Conn) (r int64, w int64, retErr error) {
 				fmt.Fprintf(os.Stderr, "DEBUG: %s>%s: ACME TLS-ALPN falls through (no termination found)\n", domain, alpns[0])
 			}
 
-			// happy path, e.g. "example.com:h2"
-			snialpn = NewSNIALPN(domain, alpns[0])
-			mcfg, exists := lc.configBySNIALPN[snialpn]
-			if !exists {
-				if len(alpns) > 1 {
-					// still happy path, e.g. "example.com:http/1.1"
-					snialpn = NewSNIALPN(domain, alpns[1])
-					mcfg, exists = lc.configBySNIALPN[snialpn]
+			var mcfg *ConfigService
+			{
+				trackMismatch := func() {
+					key := domain + ":" + alpns[0]
+					vAny, ok := lc.TLSMismatches.Load(key)
+					if !ok {
+						vAny = &atomic.Int32{}
+						lc.TLSMismatches.Store(key, vAny)
+					}
+					v := vAny.(*atomic.Int32)
+					v.Add(1)
 				}
 
-				// unhappy path
-				if !exists {
-					trackMismatch := func() {
-						key := domain + ":" + alpns[0]
-						vAny, ok := lc.TLSMismatches.Load(key)
-						if !ok {
-							vAny = &atomic.Int32{}
-							lc.TLSMismatches.Store(key, vAny)
-						}
-						v := vAny.(*atomic.Int32)
-						v.Add(1)
+				var err error
+				snialpn, mcfg, err = lc.matchService(&conf, domain, alpns)
+				if err == nil {
+					fmt.Fprintf(os.Stderr, "DEBUG: %s: match: %s, %d backends\n", snialpn, strings.Join(mcfg.Domains, ", "), len(mcfg.Backends))
+				}
+				if err != nil {
+					snialpn = NewSNIALPN(domain, alpns[0])
+					fmt.Fprintf(os.Stderr, "DEBUG: %s>%s: match err: %#v\n", domain, alpns[0], err)
+					if !slices.Contains(conf.AdminDNS.Domains, domain) {
+						trackMismatch()
+						return nil, err
 					}
 
-					var err error
-					snialpn, mcfg, err = lc.slowMatchService(&conf, domain, alpns)
-					if err == nil {
-						fmt.Fprintf(os.Stderr, "DEBUG: %s: slowMatch: %s, %d backends\n", snialpn, strings.Join(mcfg.Domains, ", "), len(mcfg.Backends))
+					var clientALPN string
+					adminALPNs := []string{"h2", "http/1.1"}
+					for _, alpn := range hello.SupportedProtos {
+						if slices.Contains(adminALPNs, alpn) {
+							clientALPN = alpn
+							break
+						}
 					}
-					if err != nil {
-						snialpn = NewSNIALPN(domain, alpns[0])
-						fmt.Fprintf(os.Stderr, "DEBUG: %s>%s: slowMatch err: %#v\n", domain, alpns[0], err)
-						if !slices.Contains(conf.AdminDNS.Domains, domain) {
-							trackMismatch()
-							return nil, err
-						}
-
-						var clientALPN string
-						adminALPNs := []string{"h2", "http/1.1"}
-						for _, alpn := range hello.SupportedProtos {
-							if slices.Contains(adminALPNs, alpn) {
-								clientALPN = alpn
-								break
-							}
-						}
-						if len(clientALPN) == 0 {
-							trackMismatch()
-							return nil, err
-						}
-
-						backend = &Backend{
-							TerminateTLS: true,
-							HTTPTunnel:   lc.adminTunnel,
-						}
-						_ = wconn.Passthru()
-						if lc.certmagicConfMap[domain] == nil {
-							return nil, fmt.Errorf("SANITY FAIL: %s: missing ACME config", snialpn)
-						}
-						fmt.Fprintf(os.Stderr, "DEBUG: %s: returning tls.Config with admin certmagic m.GetCertificate\n", snialpn)
-						return &tls.Config{
-							GetCertificate: lc.certmagicConfMap[domain].GetCertificate,
-							NextProtos:     []string{clientALPN},
-						}, nil
+					if len(clientALPN) == 0 {
+						trackMismatch()
+						return nil, err
 					}
+
+					backend = &Backend{
+						TerminateTLS: true,
+						HTTPTunnel:   lc.adminTunnel,
+					}
+					_ = wconn.Passthru()
+					if lc.certmagicConfMap[domain] == nil {
+						return nil, fmt.Errorf("SANITY FAIL: %s: missing ACME config", snialpn)
+					}
+					fmt.Fprintf(os.Stderr, "DEBUG: %s: returning tls.Config with admin certmagic m.GetCertificate\n", snialpn)
+					return &tls.Config{
+						GetCertificate: lc.certmagicConfMap[domain].GetCertificate,
+						NextProtos:     []string{clientALPN},
+					}, nil
 				}
 			}
 
@@ -1142,11 +1138,11 @@ func (lc *ListenConfig) proxy(conn net.Conn) (r int64, w int64, retErr error) {
 
 			magic := lc.certmagicConfMap[domain]
 			if magic == nil {
-				lc.slowConfigMu.RLock()
+				lc.serviceMu.RLock()
 				if _, ok := lc.slowCertmagicConfMap[domain]; ok {
 					magic = lc.certmagicTLSALPNOnly
 				}
-				lc.slowConfigMu.RUnlock()
+				lc.serviceMu.RUnlock()
 				if magic == nil {
 					return nil, fmt.Errorf("SANITY FAIL: %s: found backend but missing ACME config", snialpn)
 				}
@@ -1388,18 +1384,17 @@ func getBackendConn(ctx context.Context, backendAddr string) (net.Conn, error) {
 	return d.DialContext(ctx, "tcp", backendAddr)
 }
 
-// slowMatch handles non-static matches - such as ip-as-hostname, wildcard, and CNAME/SRV records
-func (lc *ListenConfig) slowMatchService(conf *Config, domain string, alpns []string) (SNIALPN, *ConfigService, error) {
+func (lc *ListenConfig) matchService(conf *Config, domain string, alpns []string) (SNIALPN, *ConfigService, error) {
 	{
 		snialpn := NewSNIALPN(domain, alpns[0])
 
-		lc.slowConfigMu.RLock()
-		entry, exists := lc.slowConfigBySNIALPN[snialpn]
+		lc.serviceMu.RLock()
+		entry, exists := lc.serviceBySNIALPN[snialpn]
 		if !exists && len(alpns) > 1 {
 			snialpn = NewSNIALPN(domain, alpns[1])
-			entry, exists = lc.slowConfigBySNIALPN[snialpn]
+			entry, exists = lc.serviceBySNIALPN[snialpn]
 		}
-		lc.slowConfigMu.RUnlock()
+		lc.serviceMu.RUnlock()
 
 		if exists {
 			svc, ok := lc.refreshCacheEntry(entry, conf, domain, alpns, snialpn)
@@ -1409,23 +1404,29 @@ func (lc *ListenConfig) slowMatchService(conf *Config, domain string, alpns []st
 		}
 	}
 
-	// we already checked the first two, if any
+	// ALPN fallback: check remaining ALPNs beyond the first two
 	if len(alpns) > 2 {
 		knownAlpns := lc.alpnsByDomain[domain]
 
 		for _, alpn := range alpns[2:] {
 			if slices.Contains(knownAlpns, alpn) {
 				snialpn := NewSNIALPN(domain, alpn)
-				return snialpn, lc.configBySNIALPN[snialpn], nil
+				lc.serviceMu.RLock()
+				entry := lc.serviceBySNIALPN[snialpn]
+				lc.serviceMu.RUnlock()
+				return snialpn, entry.service, nil
 			}
 		}
 		if slices.Contains(knownAlpns, "*") {
 			snialpn := NewSNIALPN(domain, "*")
-			return snialpn, lc.configBySNIALPN[snialpn], nil
+			lc.serviceMu.RLock()
+			entry := lc.serviceBySNIALPN[snialpn]
+			lc.serviceMu.RUnlock()
+			return snialpn, entry.service, nil
 		}
 	}
 
-	// treating ".example.com" is a wildcard
+	// wildcard: ".example.com" matches "sub.example.com"
 	subDomain := domain
 	for {
 		nextDot := strings.IndexByte(subDomain, '.')
@@ -1438,13 +1439,18 @@ func (lc *ListenConfig) slowMatchService(conf *Config, domain string, alpns []st
 		for _, alpn := range alpns {
 			if slices.Contains(knownAlpns, alpn) {
 				snialpn := NewSNIALPN(subDomain, alpn)
-				return snialpn, lc.configBySNIALPN[snialpn], nil
+				lc.serviceMu.RLock()
+				entry := lc.serviceBySNIALPN[snialpn]
+				lc.serviceMu.RUnlock()
+				return snialpn, entry.service, nil
 			}
 		}
-		isWild := slices.Contains(knownAlpns, "*")
-		if isWild {
+		if slices.Contains(knownAlpns, "*") {
 			snialpn := NewSNIALPN(subDomain, "*")
-			return snialpn, lc.configBySNIALPN[snialpn], nil
+			lc.serviceMu.RLock()
+			entry := lc.serviceBySNIALPN[snialpn]
+			lc.serviceMu.RUnlock()
+			return snialpn, entry.service, nil
 		}
 
 		subDomain = subDomain[1:]
@@ -1485,9 +1491,9 @@ func (lc *ListenConfig) refreshCacheEntry(entry *dnsCacheEntry, conf *Config, do
 			lc.resolveOrExtend(conf, domain, alpns)
 			return nil, nil
 		})
-		lc.slowConfigMu.RLock()
-		entry = lc.slowConfigBySNIALPN[snialpn]
-		lc.slowConfigMu.RUnlock()
+		lc.serviceMu.RLock()
+		entry = lc.serviceBySNIALPN[snialpn]
+		lc.serviceMu.RUnlock()
 		if entry != nil {
 			return entry.service, true
 		}
@@ -1510,18 +1516,18 @@ func (lc *ListenConfig) resolveOrExtend(conf *Config, domain string, alpns []str
 	fmt.Fprintf(os.Stderr, "WARN: DNS refresh for %s failed: %v, extending cached entry\n", domain, err)
 
 	snialpn := NewSNIALPN(domain, alpns[0])
-	lc.slowConfigMu.Lock()
-	entry, exists := lc.slowConfigBySNIALPN[snialpn]
+	lc.serviceMu.Lock()
+	entry, exists := lc.serviceBySNIALPN[snialpn]
 	if !exists && len(alpns) > 1 {
 		snialpn = NewSNIALPN(domain, alpns[1])
-		entry, exists = lc.slowConfigBySNIALPN[snialpn]
+		entry, exists = lc.serviceBySNIALPN[snialpn]
 	}
 	if exists {
 		now := time.Now()
 		entry.staleAt = now.Add(minTTL)
 		entry.expiredAt = now.Add(minTTL + staleTTL)
 	}
-	lc.slowConfigMu.Unlock()
+	lc.serviceMu.Unlock()
 }
 
 func newWrappedConn(conn net.Conn) *wrappedConn {

--- a/vendor/github.com/therootcompany/golib/net/gitshallow/LICENSE
+++ b/vendor/github.com/therootcompany/golib/net/gitshallow/LICENSE
@@ -1,0 +1,8 @@
+Copyright 2021-present AJ ONeal <aj@therootcompany.com>
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+This Source Code Form is "Incompatible With Secondary Licenses", as
+defined by the Mozilla Public License, v. 2.0.

--- a/vendor/github.com/therootcompany/golib/net/gitshallow/gitshallow.go
+++ b/vendor/github.com/therootcompany/golib/net/gitshallow/gitshallow.go
@@ -1,0 +1,313 @@
+package gitshallow
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+)
+
+// Repo manages a shallow git clone used as a periodically-updated data source.
+type Repo struct {
+	URL    string
+	Path   string
+	Depth  int    // 0 defaults to 1, -1 for all
+	Branch string // Optional: specific branch to clone/pull
+
+	// MaxAge skips the git fetch when .git/FETCH_HEAD is younger than this
+	// duration. Persists across process restarts (unlike the in-process
+	// singleflight dedup) — so repeated short-lived CLI invocations don't
+	// hammer the remote. 0 defaults to 1 minute; -1 disables.
+	MaxAge time.Duration
+
+	// GCInterval controls explicit aggressive GC after pulls.
+	//   0 (default) — no explicit gc; git runs gc.auto on its own schedule
+	//   1           — aggressive gc after every pull
+	//   N           — aggressive gc after every Nth pull
+	GCInterval int
+
+	sf        singleflight.Group
+	mu        sync.Mutex // guards pullCount
+	pullCount int
+}
+
+// New creates a new Repo instance.
+func New(url, path string, depth int, branch string) *Repo {
+	return &Repo{
+		URL:    url,
+		Path:   path,
+		Depth:  depth,
+		Branch: strings.TrimSpace(branch),
+	}
+}
+
+// validRef matches branch/ref names that are safe to pass to git as a
+// positional argument: no leading dash (which git would treat as a flag),
+// no whitespace, no shell metacharacters.
+var validRef = regexp.MustCompile(`^[A-Za-z0-9._/-]+$`)
+
+// validateArgs rejects branch values git would interpret as options.
+// URL is passed to git after a `--` flag terminator, so git won't
+// reinterpret a leading `-` as an option.
+func (r *Repo) validateArgs() error {
+	if _, err := url.Parse(r.URL); err != nil {
+		return fmt.Errorf("invalid URL %q: %w", r.URL, err)
+	}
+	if r.Branch != "" && !validRef.MatchString(r.Branch) {
+		return fmt.Errorf("branch %q contains invalid characters", r.Branch)
+	}
+	return nil
+}
+
+// effectiveDepth returns the depth to use for clone/pull.
+// 0 means unset — defaults to 1. -1 means full history.
+func (r *Repo) effectiveDepth() int {
+	if r.Depth == 0 {
+		return 1
+	}
+	return r.Depth
+}
+
+// effectiveMaxAge returns the MaxAge to apply.
+// 0 means unset — defaults to 1 minute. -1 disables the gate.
+func (r *Repo) effectiveMaxAge() time.Duration {
+	switch {
+	case r.MaxAge == 0:
+		return time.Minute
+	case r.MaxAge < 0:
+		return 0
+	default:
+		return r.MaxAge
+	}
+}
+
+func (r *Repo) clone(ctx context.Context) (bool, error) {
+	if r.exists() {
+		return false, nil
+	}
+	if r.URL == "" {
+		return false, fmt.Errorf("repository URL is required")
+	}
+	if r.Path == "" {
+		return false, fmt.Errorf("local path is required")
+	}
+	if err := r.validateArgs(); err != nil {
+		return false, err
+	}
+	if err := os.MkdirAll(filepath.Dir(r.Path), 0o755); err != nil {
+		return false, err
+	}
+
+	args := []string{"clone", "--no-tags"}
+	if depth := r.effectiveDepth(); depth >= 0 {
+		args = append(args, "--depth", fmt.Sprintf("%d", depth))
+	}
+	args = append(args, "--single-branch")
+	if r.Branch != "" {
+		args = append(args, "--branch", r.Branch)
+	}
+	// `--` separates flags from positional URL/path so a URL beginning
+	// with `-` cannot be reinterpreted by git as an option.
+	args = append(args, "--", r.URL, filepath.Base(r.Path))
+
+	_, err := r.runGit(ctx, args...)
+	return true, err
+}
+
+// exists checks if the directory contains a .git folder.
+func (r *Repo) exists() bool {
+	_, err := os.Stat(filepath.Join(r.Path, ".git"))
+	return err == nil
+}
+
+// runGit executes a git command in the repo directory (or parent for clone).
+// ctx cancels the child git process via SIGKILL.
+func (r *Repo) runGit(ctx context.Context, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	if _, err := os.Stat(r.Path); err == nil && r.exists() {
+		cmd.Dir = r.Path
+	} else {
+		cmd.Dir = filepath.Dir(r.Path)
+	}
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		// Redact userinfo from both the args echo (we may have just passed
+		// r.URL) and from git's own output (git embeds the URL in messages
+		// like "fatal: unable to access 'https://user:pass@host/'"). If a
+		// caller put credentials in the URL — even though the docs steer
+		// them to Authorization headers — they don't end up in error logs.
+		safeArgs := redactUserinfo(strings.Join(args, " "), r.URL)
+		safeOut := redactUserinfo(string(output), r.URL)
+		return "", fmt.Errorf("git %s failed: %w\n%s", safeArgs, err, safeOut)
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+// redactUserinfo returns s with any "user:pass@" or "user@" segment from
+// rawURL replaced with "redacted@". No-op if rawURL has no userinfo.
+func redactUserinfo(s, rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.User == nil {
+		return s
+	}
+	return strings.ReplaceAll(s, u.User.String()+"@", "redacted@")
+}
+
+func (r *Repo) pull(ctx context.Context) (updated bool, err error) {
+	if !r.exists() {
+		return false, fmt.Errorf("repository does not exist at %s", r.Path)
+	}
+	if err := r.validateArgs(); err != nil {
+		return false, err
+	}
+
+	oldHead, _ := r.runGit(ctx, "rev-parse", "HEAD")
+
+	branch := r.Branch
+	if branch == "" {
+		out, err := r.runGit(ctx, "symbolic-ref", "--short", "refs/remotes/origin/HEAD")
+		if err != nil {
+			return false, err
+		}
+		_, branch, _ = strings.Cut(out, "/")
+		if !validRef.MatchString(branch) {
+			return false, fmt.Errorf("remote default branch %q contains invalid characters", branch)
+		}
+	}
+
+	fetchArgs := []string{"fetch", "--no-tags"}
+	if depth := r.effectiveDepth(); depth >= 0 {
+		fetchArgs = append(fetchArgs, "--depth", fmt.Sprintf("%d", depth))
+	}
+	// `--` separates flags from positional remote/branch.
+	fetchArgs = append(fetchArgs, "--", "origin", branch)
+	if _, err := r.runGit(ctx, fetchArgs...); err != nil {
+		return false, err
+	}
+
+	if _, err := r.runGit(ctx, "reset", "--hard", "origin/"+branch); err != nil {
+		return false, err
+	}
+
+	newHead, err := r.runGit(ctx, "rev-parse", "HEAD")
+	if err != nil {
+		return false, err
+	}
+	return oldHead != newHead, nil
+}
+
+func (r *Repo) gc(ctx context.Context) error {
+	if !r.exists() {
+		return fmt.Errorf("repository does not exist at %s", r.Path)
+	}
+	_, err := r.runGit(ctx, "gc", "--aggressive", "--prune=now")
+	return err
+}
+
+// Fetch clones the repo if missing, pulls otherwise, and conditionally runs
+// GC based on GCInterval. Returns whether HEAD changed. Implements Fetcher.
+// Safe to call concurrently — concurrent callers share a single in-flight
+// fetch (via singleflight) and all receive the same result. To force a
+// pull regardless of MaxAge, set MaxAge=-1 before calling.
+func (r *Repo) Fetch(ctx context.Context) (updated bool, err error) {
+	// MaxAge: file-mtime gate (FETCH_HEAD is rewritten on every successful
+	// fetch, so its mtime is "last time we talked to the remote").
+	if maxAge := r.effectiveMaxAge(); maxAge > 0 {
+		if info, err := os.Stat(filepath.Join(r.Path, ".git", "FETCH_HEAD")); err == nil {
+			if time.Since(info.ModTime()) < maxAge {
+				return false, nil
+			}
+		}
+	}
+
+	v, err, _ := r.sf.Do("fetch", func() (any, error) {
+		return r.fetch(ctx)
+	})
+	if err != nil {
+		return false, err
+	}
+	return v.(bool), nil
+}
+
+func (r *Repo) fetch(ctx context.Context) (bool, error) {
+	if cloned, err := r.clone(ctx); err != nil {
+		return false, err
+	} else if cloned {
+		return true, nil
+	}
+
+	updated, err := r.pull(ctx)
+	if err != nil {
+		return false, err
+	}
+	if !updated {
+		return false, nil
+	}
+
+	if r.GCInterval > 0 {
+		r.mu.Lock()
+		r.pullCount++
+		shouldGC := r.pullCount%r.GCInterval == 0
+		r.mu.Unlock()
+		if shouldGC {
+			return true, r.gc(ctx)
+		}
+	}
+
+	return true, nil
+}
+
+// FilePath returns the absolute path to relPath within this repo.
+func (r *Repo) FilePath(rel string) string {
+	return filepath.Join(r.Path, rel)
+}
+
+// File returns a handle to relPath within this repo. The handle's Path and
+// Open methods give access to the file; its Fetch method syncs the repo and
+// reports whether this specific file changed (by mtime).
+func (r *Repo) File(relPath string) *RepoFile {
+	return &RepoFile{repo: r, rel: relPath}
+}
+
+// RepoFile is a handle to a single file inside a Repo. Fetch syncs the repo
+// (deduped across all RepoFile handles sharing the same Repo) and reports
+// whether this file changed. The Repo prefix avoids collision with os.File,
+// which is the type returned by Open.
+type RepoFile struct {
+	repo    *Repo
+	rel     string
+	mu      sync.Mutex
+	lastMod time.Time
+}
+
+// Path returns the absolute path to the file.
+func (f *RepoFile) Path() string {
+	return filepath.Join(f.repo.Path, f.rel)
+}
+
+// Fetch syncs the repo and reports whether this file changed since last call.
+// Safe to call concurrently. Implements Fetcher.
+func (f *RepoFile) Fetch(ctx context.Context) (bool, error) {
+	if _, err := f.repo.Fetch(ctx); err != nil {
+		return false, err
+	}
+	info, err := os.Stat(f.Path())
+	if err != nil {
+		return false, err
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if info.ModTime().Equal(f.lastMod) {
+		return false, nil
+	}
+	f.lastMod = info.ModTime()
+	return true, nil
+}

--- a/vendor/github.com/therootcompany/golib/net/ipcohort/LICENSE
+++ b/vendor/github.com/therootcompany/golib/net/ipcohort/LICENSE
@@ -1,0 +1,8 @@
+Copyright 2021-present AJ ONeal <aj@therootcompany.com>
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+This Source Code Form is "Incompatible With Secondary Licenses", as
+defined by the Mozilla Public License, v. 2.0.

--- a/vendor/github.com/therootcompany/golib/net/ipcohort/README.md
+++ b/vendor/github.com/therootcompany/golib/net/ipcohort/README.md
@@ -1,0 +1,36 @@
+# [ipcohort](https://github.com/therootcompany/golib/tree/main/net/ipcohort)
+
+A memory-efficient, fast IP cohort checker for blacklists, whitelists, and ad cohorts.
+
+- 4 bytes per /32 host, 5 bytes per CIDR range (8 with alignment padding)
+- O(log n) binary search across both hosts and CIDR ranges
+- immutable cohorts — callers swap via `atomic.Pointer` for lock-free reads
+- requires CIDR sources to be an anti-chain (no entry contained in another;
+  a /8 supersedes any /24 inside it). Most curated blocklists already
+  ship pre-normalized this way.
+
+## Example
+
+Check if an IP address belongs to a cohort (such as a blacklist):
+
+```go
+cohort, err := ipcohort.LoadFile("/srv/data/inbound.txt")
+if err != nil {
+    log.Fatalf("load: %v", err)
+}
+
+blocked, err := cohort.Contains("92.255.85.72")
+if err != nil {
+    log.Fatalf("parse: %v", err)
+}
+if blocked {
+    fmt.Println("BLOCKED")
+    os.Exit(1)
+}
+fmt.Println("allowed")
+```
+
+`Cohort.Contains(string)` parses the address each call and returns an error
+on unparseable input — callers decide fail-open vs fail-closed. If you
+already have a `netip.Addr` (e.g. from `netip.ParseAddr` on a request peer),
+use `Cohort.ContainsAddr(netip.Addr)` to skip the parse and the error.

--- a/vendor/github.com/therootcompany/golib/net/ipcohort/ipcohort.go
+++ b/vendor/github.com/therootcompany/golib/net/ipcohort/ipcohort.go
@@ -1,0 +1,264 @@
+package ipcohort
+
+import (
+	"cmp"
+	"encoding/binary"
+	"encoding/csv"
+	"errors"
+	"fmt"
+	"io"
+	"net/netip"
+	"os"
+	"slices"
+	"strings"
+)
+
+// IPv4Net represents a subnet or single address (/32).
+type IPv4Net struct {
+	networkBE uint32
+	prefix    uint8
+}
+
+func NewIPv4Net(ip4be uint32, prefix uint8) IPv4Net {
+	return IPv4Net{
+		networkBE: ip4be,
+		prefix:    prefix,
+	}
+}
+
+func (r IPv4Net) Contains(ip uint32) bool {
+	mask := uint32(0xFFFFFFFF) << (32 - r.prefix)
+	return (ip & mask) == r.networkBE
+}
+
+// Cohort is an immutable, read-only set of IPv4 addresses and subnets.
+// Contains is safe for concurrent use without locks.
+//
+// hosts holds sorted /32 addresses for O(log n) binary search.
+// nets holds CIDR ranges (prefix < 32), sorted by networkBE.
+//
+// Invariant: nets is an anti-chain — no net contains another. Cohort
+// sources are expected to ship pre-normalized (a /8 supersedes any /24
+// inside it; the /24 is omitted). Under this invariant at most one net
+// can match any IP, so Contains does a single binary search + one
+// Contains check rather than walking candidates.
+type Cohort struct {
+	hosts []uint32
+	nets  []IPv4Net
+}
+
+func sortNets(nets []IPv4Net) {
+	slices.SortFunc(nets, func(a, b IPv4Net) int {
+		return cmp.Compare(a.networkBE, b.networkBE)
+	})
+}
+
+// Size returns the total number of entries (hosts + nets).
+func (c *Cohort) Size() int {
+	return len(c.hosts) + len(c.nets)
+}
+
+// Contains reports whether ipStr falls within any host or subnet in the cohort.
+// Returns an error if ipStr is unparseable; callers decide fail-open vs
+// fail-closed for invalid input. IPv6 addresses parse but always return false
+// (cohort is IPv4-only).
+func (c *Cohort) Contains(ipStr string) (bool, error) {
+	ip, err := netip.ParseAddr(ipStr)
+	if err != nil {
+		return false, fmt.Errorf("parse %q: %w", ipStr, err)
+	}
+	return c.ContainsAddr(ip), nil
+}
+
+// ContainsAddr reports whether ip falls within any host or subnet in the cohort.
+// IPv6 addresses always return false (cohort is IPv4-only).
+func (c *Cohort) ContainsAddr(ip netip.Addr) bool {
+	if !ip.Is4() {
+		return false
+	}
+	ip4 := ip.As4()
+	ipU32 := binary.BigEndian.Uint32(ip4[:])
+
+	if _, found := slices.BinarySearch(c.hosts, ipU32); found {
+		return true
+	}
+
+	// Under the anti-chain invariant, at most one net can contain ipU32,
+	// and (when one does) it's the net with the largest networkBE <= ipU32.
+	// Binary-search for the upper bound, then check the immediate predecessor.
+	hi, _ := slices.BinarySearchFunc(c.nets, ipU32, func(n IPv4Net, target uint32) int {
+		if n.networkBE > target {
+			return 1
+		}
+		return -1
+	})
+	if hi == 0 {
+		return false
+	}
+	return c.nets[hi-1].Contains(ipU32)
+}
+
+// Parse builds a Cohort from a list of IP/CIDR strings. Returns an error
+// listing every unparseable entry; the caller decides whether to proceed
+// with a partial cohort by inspecting the returned (non-nil) Cohort.
+func Parse(prefixList []string) (*Cohort, error) {
+	var hosts []uint32
+	var nets []IPv4Net
+	var errs []error
+
+	for i, raw := range prefixList {
+		ipv4net, err := ParseIPv4(raw)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("entry %d %q: %w", i, raw, err))
+			continue
+		}
+		if ipv4net.prefix == 32 {
+			hosts = append(hosts, ipv4net.networkBE)
+		} else {
+			nets = append(nets, ipv4net)
+		}
+	}
+
+	slices.Sort(hosts)
+	sortNets(nets)
+
+	c := &Cohort{hosts: hosts, nets: nets}
+	if len(errs) > 0 {
+		return c, fmt.Errorf("ipcohort.Parse: %d invalid entries: %w",
+			len(errs), errors.Join(errs...))
+	}
+	return c, nil
+}
+
+func ParseIPv4(raw string) (ipv4net IPv4Net, err error) {
+	var ippre netip.Prefix
+	var ip netip.Addr
+	if strings.Contains(raw, "/") {
+		ippre, err = netip.ParsePrefix(raw)
+		if err != nil {
+			return ipv4net, err
+		}
+	} else {
+		ip, err = netip.ParseAddr(raw)
+		if err != nil {
+			return ipv4net, err
+		}
+		ippre = netip.PrefixFrom(ip, 32)
+	}
+
+	addr := ippre.Addr()
+	if !addr.Is4() {
+		return ipv4net, fmt.Errorf("not an IPv4 address: %s", raw)
+	}
+	ip4 := addr.As4()
+	prefix := uint8(ippre.Bits()) // 0–32
+	return NewIPv4Net(
+		binary.BigEndian.Uint32(ip4[:]),
+		prefix,
+	), nil
+}
+
+// LoadFile reads path and parses it into a Cohort. On open or read
+// errors, returns nil + error. On parse errors only, returns the partial
+// cohort + a joined error.
+func LoadFile(path string) (*Cohort, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("could not load %q: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+	return ParseCSV(f)
+}
+
+// LoadFiles loads and merges multiple files into one Cohort. Useful when
+// hosts and networks are stored in separate files.
+//
+// On open or read errors, returns nil + error. On parse errors only,
+// returns the partial cohort + a joined error so callers can choose to
+// proceed with what loaded.
+func LoadFiles(paths ...string) (*Cohort, error) {
+	var hosts []uint32
+	var nets []IPv4Net
+	var parseErrs []error
+
+	for _, path := range paths {
+		c, err := LoadFile(path)
+		if c == nil {
+			return nil, err
+		}
+		if err != nil {
+			parseErrs = append(parseErrs, fmt.Errorf("%s: %w", path, err))
+		}
+		hosts = append(hosts, c.hosts...)
+		nets = append(nets, c.nets...)
+	}
+
+	slices.Sort(hosts)
+	sortNets(nets)
+
+	c := &Cohort{hosts: hosts, nets: nets}
+	if len(parseErrs) > 0 {
+		return c, errors.Join(parseErrs...)
+	}
+	return c, nil
+}
+
+// ParseCSV parses CSV cohort data from r.
+func ParseCSV(r io.Reader) (*Cohort, error) {
+	csvReader := csv.NewReader(r)
+	csvReader.FieldsPerRecord = -1
+	return ReadAll(csvReader)
+}
+
+// ReadAll reads CSV records from r and builds a Cohort. Returns an error
+// listing every unparseable entry (with line number); the returned Cohort
+// is non-nil and contains every entry that did parse, so callers can choose
+// to proceed with a partial cohort.
+func ReadAll(r *csv.Reader) (*Cohort, error) {
+	var hosts []uint32
+	var nets []IPv4Net
+	var errs []error
+
+	for {
+		record, err := r.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("csv read error: %w", err)
+		}
+
+		if len(record) == 0 {
+			continue
+		}
+
+		raw := strings.TrimSpace(record[0])
+
+		if raw == "" || strings.HasPrefix(raw, "#") {
+			continue
+		}
+
+		ipv4net, err := ParseIPv4(raw)
+		if err != nil {
+			line, _ := r.FieldPos(0)
+			errs = append(errs, fmt.Errorf("line %d %q: %w", line, raw, err))
+			continue
+		}
+
+		if ipv4net.prefix == 32 {
+			hosts = append(hosts, ipv4net.networkBE)
+		} else {
+			nets = append(nets, ipv4net)
+		}
+	}
+
+	slices.Sort(hosts)
+	sortNets(nets)
+
+	c := &Cohort{hosts: hosts, nets: nets}
+	if len(errs) > 0 {
+		return c, fmt.Errorf("ipcohort.ReadAll: %d invalid entries: %w",
+			len(errs), errors.Join(errs...))
+	}
+	return c, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -31,6 +31,12 @@ github.com/pires/go-proxyproto
 ## explicit; go 1.24.6
 github.com/therootcompany/golib/io/transform/gsheet2csv
 github.com/therootcompany/golib/io/transform/gsheet2csv/cmd/gsheet2csv
+# github.com/therootcompany/golib/net/gitshallow v0.9.0
+## explicit; go 1.26.0
+github.com/therootcompany/golib/net/gitshallow
+# github.com/therootcompany/golib/net/ipcohort v0.9.0
+## explicit; go 1.26.0
+github.com/therootcompany/golib/net/ipcohort
 # github.com/zeebo/blake3 v0.2.4
 ## explicit; go 1.18
 github.com/zeebo/blake3


### PR DESCRIPTION
## Status

Superseded by stacked PRs. Merge these in order:

1. #40 — refactor: unify static and dynamic service maps (base, merge first)
2. #41 — feat: IP whitelist and blacklist filtering
3. #42 — fix: decouple Host header rewriting from connect_tls
4. #43 — fix: check backend reachability before ACME
5. #44 — feat: connection tracker for domain-to-IP mapping

PRs 2-5 are independent of each other; all based on #40.

## Original scope

- Unified static/dynamic service map lookup path
- IP whitelist (domains, CIDRs) and blacklist (structured tables)
- Backend reachability check before ACME
- Connection tracking (domain→IP, bytes, count) with periodic TSV flush
- Host header rewriting decoupled from connect_tls