### PR TITLE
feat: add IP whitelist and blacklist filtering

### DIFF
--- a/cmd/tlsrouter/main.go
+++ b/cmd/tlsrouter/main.go
@@ -23,10 +23,22 @@ import (
 
 	"github.com/bnnanet/tlsrouter"
 	"github.com/bnnanet/tlsrouter/ianaalpn"
+	"github.com/bnnanet/tlsrouter/internal/ipgate"
 	"github.com/bnnanet/tlsrouter/tabvault"
 
 	"github.com/joho/godotenv"
 )
+
+const defaultBlocklistRepo = "https://github.com/bitwire-it/ipblocklist.git"
+
+func defaultBlocklistPath() string {
+	dataHome := os.Getenv("XDG_DATA_HOME")
+	if dataHome == "" {
+		home, _ := os.UserHomeDir()
+		dataHome = filepath.Join(home, ".local", "share")
+	}
+	return filepath.Join(dataHome, "bitwire-it", "ipblocklist")
+}
 
 const (
 	name         = "tlsrouter"
@@ -65,14 +77,17 @@ func printVersion() {
 }
 
 type MainConfig struct {
-	showVersion  bool
-	ipDomainList string
-	networkList  string
-	port         int
-	plainPort    int
-	bind         string
-	confPath     string
-	vaultPath    string
+	showVersion     bool
+	ipDomainList    string
+	networkList     string
+	port            int
+	plainPort       int
+	bind            string
+	confPath        string
+	vaultPath       string
+	ipWhitelistPath string
+	ipBlacklistDir  string
+	ipBlacklistRepo string
 }
 
 func main() {
@@ -98,6 +113,9 @@ func main() {
 	fs.StringVar(&cfg.bind, "bind", cmp.Or(os.Getenv("BIND"), "0.0.0.0"), "Address to bind to")
 	fs.StringVar(&cfg.confPath, "config", cmp.Or(os.Getenv("CONFIG_FILE"), filepath.Join(defaultConfigDir(), "backends.csv")), "Path to backends config CSV file")
 	fs.StringVar(&cfg.vaultPath, "vault", cmp.Or(os.Getenv("VAULT_FILE"), filepath.Join(defaultConfigDir(), "secrets.tsv")), "Path to vault TSV file")
+	fs.StringVar(&cfg.ipWhitelistPath, "ip-whitelist", filepath.Join(defaultConfigDir(), "allowed.csv"), "Path to IP whitelist CSV file (IPs/CIDRs that bypass the blacklist)")
+	fs.StringVar(&cfg.ipBlacklistDir, "ip-blacklist-dir", defaultBlocklistPath(), "Path to IP blacklist data directory")
+	fs.StringVar(&cfg.ipBlacklistRepo, "ip-blacklist-repo", defaultBlocklistRepo, "Git repo URL for IP blacklist, or 'none' to disable")
 
 	fs.Usage = func() {
 		printVersion()
@@ -182,6 +200,28 @@ func main() {
 	mux := http.NewServeMux()
 	setupRouter(conf, mux)
 	lc := tlsrouter.NewListenConfig(conf)
+
+	if cfg.ipWhitelistPath != "" {
+		allowList, err := ipgate.NewDomainSet(lc.Context, cfg.ipWhitelistPath)
+		if err != nil {
+			if cfg.ipBlacklistRepo != "none" {
+				log.Fatalf("blacklist requires a whitelist for anti-lockout: %v", err)
+			}
+			log.Printf("WARN: ip-whitelist: %v (skipping)", err)
+		} else if allowList != nil {
+			lc.AllowList = allowList
+		}
+	}
+	if cfg.ipBlacklistRepo != "none" {
+		blocklist, err := ipgate.NewPrefixSet(lc.Context, cfg.ipBlacklistRepo, cfg.ipBlacklistDir, []string{
+			"tables/inbound/single_ips.txt",
+			"tables/inbound/networks.txt",
+		})
+		if err != nil {
+			log.Fatalf("ip-blacklist: %v", err)
+		}
+		lc.Blocklist = blocklist
+	}
 
 	var wg sync.WaitGroup
 	addr := fmt.Sprintf("%s:%d", cfg.bind, cfg.port)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bnnanet/tlsrouter
 
-go 1.25.6
+go 1.26.1
 
 tool github.com/therootcompany/golib/io/transform/gsheet2csv/cmd/gsheet2csv
 
@@ -11,6 +11,8 @@ require (
 	github.com/mholt/acmez/v3 v3.1.4
 	github.com/miekg/dns v1.1.69
 	github.com/pires/go-proxyproto v0.9.0
+	github.com/therootcompany/golib/net/gitshallow v0.9.0
+	github.com/therootcompany/golib/net/ipcohort v0.9.0
 	golang.org/x/sync v0.20.0
 	golang.org/x/sys v0.40.0
 )

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,10 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/therootcompany/golib/io/transform/gsheet2csv v1.0.3 h1:220hPRUieZtIc6cWlAwKbNzOJxAbscsJy83+2qIai2Q=
 github.com/therootcompany/golib/io/transform/gsheet2csv v1.0.3/go.mod h1:/GwkISS5hHJPhYIQ9B92zAfo56VuEP2NW2N10InCcWs=
+github.com/therootcompany/golib/net/gitshallow v0.9.0 h1:JNDqTD8HG4TYTmUc18Vo2MJ6tJ/12pcQo+8qG9rdV9k=
+github.com/therootcompany/golib/net/gitshallow v0.9.0/go.mod h1:S/3OK7wMOqJJjP79U9Qw/l3jjEyrb/zsjJ8HAPAX/Fc=
+github.com/therootcompany/golib/net/ipcohort v0.9.0 h1:j3AaoW2u4XQJz1ya6fixv3pb3KgxIpZV8t0082/kS3E=
+github.com/therootcompany/golib/net/ipcohort v0.9.0/go.mod h1:Ljcnt2xOryVDGIVV5Kzt5hj2LhW4lBAWo5OeeVYU9ys=
 github.com/zeebo/assert v1.1.0 h1:hU1L1vLTHsnO8x8c9KAR5GmM5QscxHg5RNU5z5qbUWY=
 github.com/zeebo/assert v1.1.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/blake3 v0.2.4 h1:KYQPkhpRtcqh0ssGYcKLG1JYvddkEA8QwCM/yBqhaZI=

--- a/internal/ipgate/domains.go
+++ b/internal/ipgate/domains.go
@@ -1,0 +1,189 @@
+package ipgate
+
+import (
+	"context"
+	"encoding/csv"
+	"fmt"
+	"io"
+	"net"
+	"net/netip"
+	"os"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/therootcompany/golib/net/ipcohort"
+)
+
+const domainSetRefreshInterval = 5 * time.Minute
+
+type domainEntry struct {
+	Raw   string
+	Label string
+}
+
+type DomainSet struct {
+	staticPrefixes []string
+	domains        []domainEntry
+	resolved       atomic.Pointer[map[string][]string]
+	cohort         atomic.Pointer[ipcohort.Cohort]
+}
+
+func EmptyDomainSet() *DomainSet {
+	ds := &DomainSet{}
+	ds.cohort.Store(&ipcohort.Cohort{})
+	return ds
+}
+
+func NewDomainSet(ctx context.Context, csvPath string) (*DomainSet, error) {
+	if csvPath == "" {
+		return nil, nil
+	}
+
+	staticPrefixes, domains, err := parseDomainSetCSV(csvPath)
+	if err != nil {
+		return nil, fmt.Errorf("domain set %q: %w", csvPath, err)
+	}
+
+	ds := &DomainSet{
+		staticPrefixes: staticPrefixes,
+		domains:        domains,
+	}
+
+	emptyResolved := make(map[string][]string)
+	ds.resolved.Store(&emptyResolved)
+
+	ds.rebuildCohort()
+
+	fmt.Fprintf(os.Stderr, "INFO: ipgate: domain set %d static + %d domains from %s (resolving in background)\n",
+		len(staticPrefixes), len(domains), csvPath)
+
+	go ds.refreshLoop(ctx)
+
+	return ds, nil
+}
+
+func (ds *DomainSet) Contains(addr netip.Addr) bool {
+	return ds.cohort.Load().ContainsAddr(addr)
+}
+
+func (ds *DomainSet) refreshLoop(ctx context.Context) {
+	ds.resolveDomains(ctx)
+	ds.rebuildCohort()
+
+	ticker := time.NewTicker(domainSetRefreshInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			ds.resolveDomains(ctx)
+			ds.rebuildCohort()
+		}
+	}
+}
+
+func (ds *DomainSet) resolveDomains(ctx context.Context) {
+	if len(ds.domains) == 0 {
+		return
+	}
+
+	prev := *ds.resolved.Load()
+	next := make(map[string][]string, len(ds.domains))
+
+	resolver := &net.Resolver{}
+	for _, entry := range ds.domains {
+		resolveCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		addrs, err := resolver.LookupHost(resolveCtx, entry.Raw)
+		cancel()
+
+		if err != nil || len(addrs) == 0 {
+			if old, ok := prev[entry.Raw]; ok {
+				next[entry.Raw] = old
+				fmt.Fprintf(os.Stderr, "WARN: ipgate: %s: resolve failed, keeping %d prior IPs: %v\n",
+					entry.Raw, len(old), err)
+			} else {
+				fmt.Fprintf(os.Stderr, "WARN: ipgate: %s: resolve failed (no prior data): %v\n",
+					entry.Raw, err)
+			}
+			continue
+		}
+
+		next[entry.Raw] = addrs
+	}
+
+	ds.resolved.Store(&next)
+}
+
+func (ds *DomainSet) rebuildCohort() {
+	var all []string
+	all = append(all, ds.staticPrefixes...)
+
+	resolved := *ds.resolved.Load()
+	for _, addrs := range resolved {
+		for _, addr := range addrs {
+			all = append(all, addr+"/32")
+		}
+	}
+
+	cohort, err := ipcohort.Parse(all)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "WARN: ipgate: domain set rebuild: %v\n", err)
+	}
+	if cohort != nil {
+		ds.cohort.Store(cohort)
+	}
+}
+
+func parseDomainSetCSV(path string) (staticPrefixes []string, domains []domainEntry, err error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer func() { _ = file.Close() }()
+
+	r := csv.NewReader(file)
+	r.FieldsPerRecord = -1
+	r.Comment = '#'
+	if strings.HasSuffix(path, ".tsv") {
+		r.Comma = '\t'
+	}
+
+	for {
+		record, readErr := r.Read()
+		if readErr == io.EOF {
+			break
+		}
+		if readErr != nil {
+			return nil, nil, fmt.Errorf("csv read: %w", readErr)
+		}
+		if len(record) == 0 {
+			continue
+		}
+
+		raw := strings.TrimSpace(record[0])
+		if raw == "" {
+			continue
+		}
+
+		var label string
+		if len(record) > 1 {
+			label = strings.TrimSpace(record[1])
+		}
+
+		if _, err := netip.ParseAddr(raw); err == nil {
+			staticPrefixes = append(staticPrefixes, raw+"/32")
+			continue
+		}
+		if _, err := netip.ParsePrefix(raw); err == nil {
+			staticPrefixes = append(staticPrefixes, raw)
+			continue
+		}
+
+		domains = append(domains, domainEntry{Raw: raw, Label: label})
+	}
+
+	return staticPrefixes, domains, nil
+}

--- a/internal/ipgate/ipprefix.go
+++ b/internal/ipgate/ipprefix.go
@@ -1,0 +1,92 @@
+package ipgate
+
+import (
+	"context"
+	"fmt"
+	"net/netip"
+	"os"
+	"sync/atomic"
+	"time"
+
+	"github.com/therootcompany/golib/net/gitshallow"
+	"github.com/therootcompany/golib/net/ipcohort"
+)
+
+const prefixSetRefreshInterval = 47 * time.Minute
+
+type PrefixSet struct {
+	repo   *gitshallow.Repo
+	files  []string
+	cohort atomic.Pointer[ipcohort.Cohort]
+}
+
+func EmptyPrefixSet() *PrefixSet {
+	ps := &PrefixSet{}
+	ps.cohort.Store(&ipcohort.Cohort{})
+	return ps
+}
+
+func NewPrefixSet(ctx context.Context, repoURL, dataPath string, files []string) (*PrefixSet, error) {
+	if err := os.MkdirAll(dataPath, 0o755); err != nil {
+		return nil, fmt.Errorf("ipgate: create data dir: %w", err)
+	}
+
+	ps := &PrefixSet{
+		repo:  gitshallow.New(repoURL, dataPath, 1, ""),
+		files: files,
+	}
+	ps.cohort.Store(&ipcohort.Cohort{})
+
+	go ps.refreshLoop(ctx)
+
+	return ps, nil
+}
+
+func (ps *PrefixSet) Contains(addr netip.Addr) bool {
+	return ps.cohort.Load().ContainsAddr(addr)
+}
+
+func (ps *PrefixSet) reload(ctx context.Context) error {
+	updated, err := ps.repo.Fetch(ctx)
+	if err != nil {
+		return err
+	}
+	if !updated && ps.cohort.Load().Size() > 0 {
+		return nil
+	}
+
+	paths := make([]string, len(ps.files))
+	for i, f := range ps.files {
+		paths[i] = ps.repo.FilePath(f)
+	}
+
+	cohort, err := ipcohort.LoadFiles(paths...)
+	if err != nil {
+		return fmt.Errorf("load files: %w", err)
+	}
+
+	ps.cohort.Store(cohort)
+
+	fmt.Fprintf(os.Stderr, "INFO: ipgate: prefix set loaded %d entries\n", cohort.Size())
+	return nil
+}
+
+func (ps *PrefixSet) refreshLoop(ctx context.Context) {
+	if err := ps.reload(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "WARN: ipgate: prefix set initial load (will retry): %v\n", err)
+	}
+
+	ticker := time.NewTicker(prefixSetRefreshInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := ps.reload(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "WARN: ipgate: prefix set reload: %v\n", err)
+			}
+		}
+	}
+}

--- a/tlsrouter.go
+++ b/tlsrouter.go
@@ -17,6 +17,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httputil"
+	"net/netip"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -32,6 +33,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/bnnanet/tlsrouter/dnsresolver"
+	"github.com/bnnanet/tlsrouter/internal/ipgate"
 	"github.com/bnnanet/tlsrouter/net/tun"
 	"github.com/bnnanet/tlsrouter/tabvault"
 
@@ -291,6 +293,8 @@ type ListenConfig struct {
 	adminServer           *http.Server
 	netLn                 net.Listener
 	dns                   *dnsresolver.Resolver
+	Blocklist             *ipgate.PrefixSet
+	AllowList             *ipgate.DomainSet
 	slowCertmagicConfMap  map[string]struct{}
 	slowACMETLS1ByDomain  map[string]*Backend
 	serviceMu             sync.RWMutex
@@ -348,6 +352,8 @@ func NewListenConfig(conf Config) *ListenConfig {
 		alpnsByDomain:         domainMatchers,
 		serviceBySNIALPN:      snialpnMatchers,
 		dns:                   dnsresolver.New(),
+		Blocklist:             ipgate.EmptyPrefixSet(),
+		AllowList:             ipgate.EmptyDomainSet(),
 		slowACMETLS1ByDomain:  make(map[string]*Backend),
 		Context:               ctx,
 		Close:                 cancel,
@@ -946,6 +952,15 @@ func (lc *ListenConfig) ListenAndProxy(addr string, mux *http.ServeMux) error {
 	for {
 		select {
 		case conn := <-ch:
+			peer, parseErr := netip.ParseAddrPort(conn.RemoteAddr().String())
+			if parseErr == nil {
+				peerAddr := peer.Addr()
+				if lc.Blocklist.Contains(peerAddr) && !lc.AllowList.Contains(peerAddr) {
+					fmt.Fprintf(os.Stderr, "INFO: rejected %s (blacklisted)\n", peerAddr)
+					_ = conn.Close()
+					continue
+				}
+			}
 			fmt.Fprintf(os.Stderr, "\nDEBUG: (new): accepted %s\n", conn.RemoteAddr())
 			go func() {
 				_, _, err = lc.proxy(conn)


### PR DESCRIPTION
## Summary
- Add `internal/ipgate` package with `Blocklist` and `Filter` types
- `Blocklist` loads from a git-managed repo (shallow clone, 47-min refresh)
- `Filter` loads IPs/CIDRs/hostnames from a whitelist CSV (5-min DNS refresh)
- Both use `atomic.Pointer` for lock-free reads and non-blocking startup
- Useful zero values: nil cohort = no blocking / no overrides
- Add `--ip-whitelist`, `--ip-blacklist-repo`, `--ip-blacklist-dir` CLI flags
- Defaults: whitelist at `~/.config/tlsrouter/allowed.csv`, blacklist data at `~/.local/share/bitwire-it/ipblocklist`
- Anti-lockout: blacklist active + missing whitelist file = fatal error

## Test plan
- [x] `go build ./cmd/tlsrouter/` compiles
- [x] `--help` shows all three new flags with correct defaults
- [x] Deployed to production target (systemd)
- [x] Service starts cleanly, whitelist loads (static + DNS entries), blocklist loads (3.5M entries)
- [x] `GET /api/version` and `GET /api/status` return correct responses
- [x] HTTP→HTTPS redirect (301) works on port 80
- [x] TLS termination and proxying works (h2, http/1.1)
- [x] Start with default blacklist repo + missing whitelist file → fatal error with clear message
- [x] Blocked IP gets `Connection reset by peer` and server logs `INFO: rejected 203.0.113.50 (blacklisted)`
- [x] Whitelisted IP (via DNS hostname → blocked IP) bypasses blacklist successfully