### PR TITLE
fix(proxy): decouple Host header rewriting from connect_tls

### DIFF
--- a/bin/tlsrouterjsontocsv/main.go
+++ b/bin/tlsrouterjsontocsv/main.go
@@ -13,6 +13,7 @@ type Backend struct {
 	Port          int    `json:"port"`
 	TerminateTLS  bool   `json:"terminate_tls"`
 	ConnectTLS    bool   `json:"connect_tls"`
+	RewriteHost   string `json:"rewrite_host"`
 	SkipTLSVerify bool   `json:"connect_insecure"`
 }
 
@@ -46,17 +47,17 @@ func main() {
 	var data Data
 	_ = json.Unmarshal(bytes, &data)
 
-	fmt.Println("app_slug\tdomain\talpn\tbackend_address\tbackend_port\tterminate_tls\tconnect_tls\tconnect_insecure")
+	fmt.Println("app_slug\tdomain\talpn\tbackend_address\tbackend_port\tterminate_tls\tconnect_tls\trewrite_host\tconnect_insecure")
 
 	for _, app := range data.Apps {
 		for _, service := range app.Services {
 			for _, domain := range service.Domains {
 				for _, alpn := range service.Alpns {
 					for _, backend := range service.Backends {
-						fmt.Printf("%s\t%s\t%s\t%s\t%d\t%v\t%v\t%v\n",
+						fmt.Printf("%s\t%s\t%s\t%s\t%d\t%v\t%v\t%v\t%v\n",
 							app.Slug, domain, alpn,
 							backend.Address, backend.Port,
-							backend.TerminateTLS, backend.ConnectTLS, backend.SkipTLSVerify)
+							backend.TerminateTLS, backend.ConnectTLS, backend.RewriteHost, backend.SkipTLSVerify)
 					}
 				}
 			}

--- a/configfile.go
+++ b/configfile.go
@@ -196,6 +196,7 @@ var expectedHeaders = []string{
 	"backend_port",
 	"terminate_tls",
 	"connect_tls",
+	"rewrite_host",
 	"skip_tls_verify",
 	"auth",
 	"allowed_client_hostnames",
@@ -267,6 +268,10 @@ func ReadCSVToConfig(r *csv.Reader) (*Config, error) {
 		connectTLS := false
 		if i, ok := headerIndices["connect_tls"]; ok && i < len(record) && strings.ToLower(record[i]) == "true" {
 			connectTLS = true
+		}
+		rewriteHost := ""
+		if i, ok := headerIndices["rewrite_host"]; ok && i < len(record) {
+			rewriteHost = record[i]
 		}
 		connectInsecure := false
 		if i, ok := headerIndices["skip_tls_verify"]; ok && i < len(record) && strings.ToLower(record[i]) == "true" {
@@ -392,6 +397,7 @@ func ReadCSVToConfig(r *csv.Reader) (*Config, error) {
 				Port:          port,
 				TerminateTLS:  terminateTLS,
 				ConnectTLS:    connectTLS,
+				RewriteHost:   rewriteHost,
 				SkipTLSVerify: connectInsecure,
 				AuthToken:     authToken,
 			}
@@ -432,6 +438,7 @@ type CSVRecord struct {
 	BackendPort            uint16
 	TerminateTLS           bool
 	ConnectTLS             bool
+	RewriteHost            string
 	SkipTLSVerify          bool
 	Auth                   string
 	AllowedClientHostnames string
@@ -464,6 +471,7 @@ func (c *Config) ToRecords() ([]CSVRecord, error) {
 							BackendPort:            backend.Port,
 							TerminateTLS:           backend.TerminateTLS,
 							ConnectTLS:             backend.ConnectTLS,
+							RewriteHost:            backend.RewriteHost,
 							SkipTLSVerify:          backend.SkipTLSVerify,
 							Auth:                   backend.AuthToken,
 							AllowedClientHostnames: strings.Join(service.AllowedClientHostnames, ";"),
@@ -503,6 +511,9 @@ func (c *Config) ToRecords() ([]CSVRecord, error) {
 		if a.ConnectTLS != b.ConnectTLS {
 			return strings.Compare(fmt.Sprintf("%t", a.ConnectTLS), fmt.Sprintf("%t", b.ConnectTLS))
 		}
+		if a.RewriteHost != b.RewriteHost {
+			return strings.Compare(a.RewriteHost, b.RewriteHost)
+		}
 		if a.SkipTLSVerify != b.SkipTLSVerify {
 			return strings.Compare(fmt.Sprintf("%t", a.SkipTLSVerify), fmt.Sprintf("%t", b.SkipTLSVerify))
 		}
@@ -532,6 +543,7 @@ func RecordsToCSV(csvw *csv.Writer, records []CSVRecord) error {
 			fmt.Sprintf("%d", record.BackendPort),
 			fmt.Sprintf("%t", record.TerminateTLS),
 			fmt.Sprintf("%t", record.ConnectTLS),
+			record.RewriteHost,
 			fmt.Sprintf("%t", record.SkipTLSVerify),
 			record.Auth,
 			record.AllowedClientHostnames,

--- a/dynamic-config.go
+++ b/dynamic-config.go
@@ -135,6 +135,7 @@ func (lc *ListenConfig) buildService(conf *Config, domain string, route *dnsRout
 		Port:          route.Port,
 		TerminateTLS:  route.Terminate,
 		ConnectTLS:    false,
+		RewriteHost:   "",
 		SkipTLSVerify: false,
 	}
 

--- a/tlsrouter.go
+++ b/tlsrouter.go
@@ -237,6 +237,7 @@ type Backend struct {
 	TerminateTLS  bool               `json:"terminate_tls"`
 	ForceHTTP     bool               `json:"force_http,omitempty"`
 	ConnectTLS    bool               `json:"connect_tls"`
+	RewriteHost   string             `json:"rewrite_host,omitempty"`
 	SkipTLSVerify bool               `json:"connect_insecure"`
 	AuthToken     string             `json:"auth_token,omitempty"`
 	// Healthy         *atomic.Bool       `json:"-"`
@@ -606,12 +607,18 @@ func (lc *ListenConfig) setupHTTPReverseProxy(domain string, backend *Backend, v
 	proxy := &httputil.ReverseProxy{
 		Rewrite: func(r *httputil.ProxyRequest) {
 			r.SetURL(target)
-			if backend.ConnectTLS {
+			switch strings.ToLower(backend.RewriteHost) {
+			case "", "false":
+				r.Out.Host = r.In.Host
+			case "true":
 				inHost := r.In.Host
 				rewriteHeaderHost(r.Out.Header, "Referer", inHost, target.Host)
 				rewriteHeaderHost(r.Out.Header, "Origin", inHost, target.Host)
-			} else {
-				r.Out.Host = r.In.Host // preserve original Host for plaintext backends
+			default:
+				inHost := r.In.Host
+				r.Out.Host = backend.RewriteHost
+				rewriteHeaderHost(r.Out.Header, "Referer", inHost, backend.RewriteHost)
+				rewriteHeaderHost(r.Out.Header, "Origin", inHost, backend.RewriteHost)
 			}
 			r.Out.Header.Del("X-Real-IP") // not auto-stripped
 			// We are the trust boundary: r.In.RemoteAddr is the real


### PR DESCRIPTION
## Summary
- Add rewrite_host column to backends.csv
- Host/Origin/Referer rewriting now configurable independently of TLS re-encryption

## Test plan
- [x] Deploy to vms.oneal.im, existing backends unaffected
- [ ] Test with explicit rewrite_host set