### PR TITLE
fix(acme): check backend reachability before ACME

### DIFF
--- a/dynamic-config.go
+++ b/dynamic-config.go
@@ -18,6 +18,7 @@ import (
 
 var errTryNext = fmt.Errorf("no worries, carry on")
 var errIPNotInNetwork = fmt.Errorf("target IP not in any allowed network")
+var errNoMatchingRecord = fmt.Errorf("no matching CNAME or SRV record")
 
 // use standard ports for servers that natively handle internet traffic via TLS
 var rawPortMap = map[string]uint16{
@@ -398,7 +399,7 @@ func getAllowedSrv(
 			return best, nil
 		}
 	}
-	return nil, fmt.Errorf("no matching CNAME or SRV record for %q with offered ALPNs", domain)
+	return nil, fmt.Errorf("%w for %q with offered ALPNs", errNoMatchingRecord, domain)
 }
 
 func findSrvForALPN(

--- a/dynamic-config.go
+++ b/dynamic-config.go
@@ -16,8 +16,8 @@ import (
 	"github.com/bnnanet/tlsrouter/dnsresolver"
 )
 
-var ErrUnknownNetwork = fmt.Errorf("the target ip is not part of a known network")
 var errTryNext = fmt.Errorf("no worries, carry on")
+var errIPNotInNetwork = fmt.Errorf("target IP not in any allowed network")
 
 // use standard ports for servers that natively handle internet traffic via TLS
 var rawPortMap = map[string]uint16{
@@ -102,17 +102,23 @@ func dbg(tmpl string, args ...any) {
 }
 
 func (lc *ListenConfig) resolveRoute(ctx context.Context, conf *Config, domain string, alpns []string) (*dnsRoute, error) {
-	route, err := getAllowedIP(conf, domain, alpns)
-	if err != nil {
-		if err != errTryNext {
-			return nil, err
-		}
-		route, err = getAllowedSrv(ctx, lc.dns, conf, domain, alpns)
-		if err != nil {
-			return nil, err
-		}
+	route, ipErr := getAllowedIP(conf, domain, alpns)
+	if ipErr == nil {
+		return route, nil
 	}
-	return route, nil
+	if ipErr != errTryNext && ipErr != errIPNotInNetwork {
+		return nil, ipErr
+	}
+
+	route, srvErr := getAllowedSrv(ctx, lc.dns, conf, domain, alpns)
+	if srvErr == nil {
+		return route, nil
+	}
+
+	if ipErr == errIPNotInNetwork {
+		return nil, fmt.Errorf("%s: %w; also %w", domain, ipErr, srvErr)
+	}
+	return nil, errTryNext
 }
 
 func (lc *ListenConfig) buildService(conf *Config, domain string, route *dnsRoute) (SNIALPN, *ConfigService) {
@@ -164,11 +170,29 @@ func (lc *ListenConfig) cacheService(snialpn SNIALPN, domain string, service *Co
 	lc.serviceMu.Unlock()
 
 	if route.Terminate {
+		if err := checkBackendReachable(route.IP.String(), route.Port); err != nil {
+			return fmt.Errorf("backend unreachable for %s, skipping ACME: %w", domain, err)
+		}
 		if err := lc.certmagicTLSALPNOnly.ManageSync(lc.Context, []string{domain}); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func checkBackendReachable(ip string, port uint16) error {
+	targets := []string{net.JoinHostPort(ip, strconv.Itoa(int(port)))}
+	if port != 22 {
+		targets = append(targets, net.JoinHostPort(ip, "22"))
+	}
+	for _, addr := range targets {
+		conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
+		if err == nil {
+			conn.Close()
+			return nil
+		}
+	}
+	return fmt.Errorf("tcp dial failed for %s on port %d and ssh", ip, port)
 }
 
 func getAllowedIP(
@@ -206,7 +230,7 @@ func getAllowedIP(
 	}
 
 	if !conf.IsAllowedIP(ip) {
-		return nil, errTryNext
+		return nil, errIPNotInNetwork
 	}
 
 	var selectedALPN string
@@ -374,7 +398,7 @@ func getAllowedSrv(
 			return best, nil
 		}
 	}
-	return nil, errors.New("no matching SRV found for offered ALPNs")
+	return nil, fmt.Errorf("no matching CNAME or SRV record for %q with offered ALPNs", domain)
 }
 
 func findSrvForALPN(
@@ -495,7 +519,7 @@ func checkSRV(
 	}
 
 	if !conf.IsAllowedIP(ip) {
-		return nil, ErrUnknownNetwork
+		return nil, errIPNotInNetwork
 	}
 
 	return &dnsRoute{

--- a/skills/tlsrouter-deploy-test/SKILL.md
+++ b/skills/tlsrouter-deploy-test/SKILL.md
@@ -174,6 +174,42 @@ VERIFY: production service healthy
 curl -sS --connect-timeout 3 https://TARGET_DOMAIN/api/version
 ```
 
+## 8. Test ACME reachability check
+
+The reachability check prevents wasted ACME attempts against unreachable backends.
+Requires `--networks` to include the target subnet and `--ip-domains` to match the SLD.
+
+### 8a. Reachable backend succeeds
+
+```sh
+curl -sS --connect-timeout 5 https://tls-10-0-2-21.TARGET_DOMAIN/ -o /dev/null -w "%{http_code}\n"
+# expect: 200 (backend is up, ACME succeeds)
+```
+
+### 8b. Unreachable backend in allowed network
+
+```sh
+curl -sS --connect-timeout 10 https://tls-10-0-2-249.TARGET_DOMAIN/ -o /dev/null -w "%{http_code}\n"
+# expect: SSL error (connection reset)
+```
+
+VERIFY: logs show `backend unreachable for ... skipping ACME`
+```sh
+ssh TARGET_HOST "sudo journalctl -u tlsrouter --since '30 sec ago' --no-pager | grep unreachable"
+```
+
+### 8c. IP outside allowed networks
+
+```sh
+curl -sS --connect-timeout 10 https://tls-10-249-249-249.TARGET_DOMAIN/ -o /dev/null -w "%{http_code}\n"
+# expect: SSL error (connection reset)
+```
+
+VERIFY: logs show `target IP not in any allowed network`
+```sh
+ssh TARGET_HOST "sudo journalctl -u tlsrouter --since '30 sec ago' --no-pager | grep 'not in any allowed'"
+```
+
 ## Notes
 
 - Port 8443 or other non-standard ports may be firewalled. Test on the production port (443) with controlled blocklist data.

--- a/skills/tlsrouter-deploy-test/SKILL.md
+++ b/skills/tlsrouter-deploy-test/SKILL.md
@@ -9,88 +9,51 @@ description: Deploy and test tlsrouter on a systemd target. Use when deploying a
 
 - SSH access to target host
 - Target runs systemd with `tlsrouter.service`
-- Service file at `/etc/systemd/system/tlsrouter.service`
 - Binary deployed to `~/bin/tlsrouter` (as service user)
 - Check `memory/reference_deploy_targets.md` for host-specific service manager (systemd vs OpenRC)
 
-## 1. Build
-
-Cross-compile for target architecture (typically linux/amd64):
+## 1. Build and deploy
 
 ```sh
-LDFLAGS="-X main.version=$(git describe --tags --always) -X main.commit=$(git rev-parse --short HEAD) -X main.date=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-GOOS=linux GOARCH=amd64 go build -ldflags "$LDFLAGS" -o ./agents/tmp/tlsrouter-linux-amd64 ./cmd/tlsrouter/
+./skills/tlsrouter-deploy-test/scripts/build-and-deploy.sh TARGET_HOST
 ```
 
-VERIFY: file exists and is linux binary
-```sh
-file ./agents/tmp/tlsrouter-linux-amd64
-# expect: ELF 64-bit LSB executable, x86-64
-```
+VERIFY: script prints remote version matching current commit
 
-## 2. Deploy binary
-
-```sh
-scp ./agents/tmp/tlsrouter-linux-amd64 TARGET_HOST:~/bin/tlsrouter.new
-ssh TARGET_HOST "mv ~/bin/tlsrouter.new ~/bin/tlsrouter && chmod +x ~/bin/tlsrouter"
-```
-
-VERIFY: version matches on remote
-```sh
-ssh TARGET_HOST "~/bin/tlsrouter --version"
-# expect: tlsrouter vX.Y.Z-N-gCOMMIT COMMIT (DATE)
-```
-
-## 3. Update systemd service (if flags changed)
+## 2. Update systemd service (if flags changed)
 
 MUST: Use `serviceman` to update the service file — never raw sed on ExecStart.
 
+Ask user for the full flag set, then run on the target:
+
 ```sh
-ssh TARGET_HOST "~/.local/bin/serviceman add --daemon --name tlsrouter -- \
-  ~/bin/tlsrouter \
-  --ip-domains proxy.example.com \
-  --networks 10.0.0.0/24 \
-  --config ~/.config/tlsrouter/backends.csv \
-  --vault ~/.config/tlsrouter/secrets.tsv \
-  --bind 0.0.0.0 \
-  --ip-whitelist ~/.config/tlsrouter/ip-whitelist.csv \
-  --ip-blacklist-dir ~/.local/share/bitwire-it/ipblocklist \
-  --ip-blacklist-repo https://github.com/ORG/ipblocklist.git"
+ssh TARGET_HOST "~/.local/bin/serviceman add --daemon --name tlsrouter -- ~/bin/tlsrouter [FLAGS]"
 ```
 
 serviceman handles daemon-reload, enable, and restart automatically.
 
 NEVER: Edit the service file with sed — broken quoting or stray comments will break the service.
 
-## 4. Restart and verify
+## 3. Test service health
 
 ```sh
-ssh TARGET_HOST "sudo systemctl restart tlsrouter"
-sleep 2
-ssh TARGET_HOST "sudo systemctl status tlsrouter --no-pager | head -10"
+./skills/tlsrouter-deploy-test/scripts/test-health.sh TARGET_DOMAIN
 ```
 
-VERIFY: Active (running), correct PID, correct ExecStart flags
+VERIFY: script prints `OK` for HTTPS reachable and HTTP redirect
 
-## 5. Test service health
+## 4. Test IP filtering
 
 ```sh
-curl -sS --connect-timeout 3 https://TARGET_DOMAIN/api/version
-curl -sS --connect-timeout 3 https://TARGET_DOMAIN/api/status
+./skills/tlsrouter-deploy-test/scripts/test-ip-filtering.sh TARGET_HOST TARGET_DOMAIN TEST_IP
 ```
 
-VERIFY: version JSON matches deployed commit, status returns uptime
+Where TEST_IP is the IP to blocklist (typically your current public IP).
 
-## 6. Test HTTP redirect
+MUST: After the script finishes, restore production config with serviceman.
+The script prints the previous ExecStart for reference.
 
-```sh
-curl -sS --connect-timeout 3 -o /dev/null -w "%{http_code}" http://TARGET_DOMAIN/
-# expect: 301
-```
-
-## 7. Test IP filtering
-
-### 7a. Fatal on missing whitelist
+### Fatal on missing whitelist (manual)
 
 Run binary with a non-existent whitelist path and active blacklist repo:
 
@@ -108,107 +71,28 @@ ssh TARGET_HOST "timeout 10 ~/bin/tlsrouter \
 
 VERIFY: output contains `blacklist requires a whitelist for anti-lockout` and `EXIT=1`
 
-### 7b. Blocked IP gets rejected
+### Whitelisted IP bypasses blacklist (manual)
 
-Create a local git repo with a test IP in the blocklist:
-
-```sh
-ssh TARGET_HOST "rm -rf /tmp/test-blocklist /tmp/test-blocklist-clone && \
-  mkdir -p /tmp/test-blocklist/tables/inbound && \
-  cd /tmp/test-blocklist && git init && \
-  git config user.email 'test@test.com' && git config user.name 'test' && \
-  echo '203.0.113.50' > tables/inbound/single_ips.txt && \
-  touch tables/inbound/networks.txt && \
-  git add -A && git commit -m 'test'"
-```
-
-Update service to use test blocklist via serviceman:
-
-```sh
-ssh TARGET_HOST "~/.local/bin/serviceman add --daemon --name tlsrouter -- \
-  ~/bin/tlsrouter \
-  --ip-domains proxy.example.com \
-  --networks 10.0.0.0/24 \
-  --config ~/.config/tlsrouter/backends.csv \
-  --vault ~/.config/tlsrouter/secrets.tsv \
-  --bind 0.0.0.0 \
-  --ip-whitelist /tmp/test-ip-whitelist.csv \
-  --ip-blacklist-dir /tmp/test-blocklist-clone \
-  --ip-blacklist-repo file:///tmp/test-blocklist"
-sleep 4
-curl -sS --connect-timeout 5 https://TARGET_DOMAIN/api/version
-# expect: "Connection reset by peer" or timeout
-```
-
-VERIFY: journalctl shows `INFO: rejected 203.0.113.50 (blacklisted)`
-```sh
-ssh TARGET_HOST "sudo journalctl -u tlsrouter --since '30 sec ago' --no-pager | grep rejected"
-```
-
-### 7c. Whitelisted IP bypasses blacklist
-
-With the test blocklist still active, add a DNS hostname or IP to the whitelist that resolves to the blocked test IP. Restart and connect again.
+With the test blocklist still active, add a DNS hostname or IP to the whitelist
+that resolves to the blocked test IP. Restart and connect again.
 
 VERIFY: connection succeeds (200 response), no rejection in logs
 
-### 7d. Cleanup
-
-MUST: Restore production config after testing:
+## 5. Test ACME reachability check
 
 ```sh
-ssh TARGET_HOST "~/.local/bin/serviceman add --daemon --name tlsrouter -- \
-  ~/bin/tlsrouter \
-  --ip-domains proxy.example.com \
-  --networks 10.0.0.0/24 \
-  --config ~/.config/tlsrouter/backends.csv \
-  --vault ~/.config/tlsrouter/secrets.tsv \
-  --bind 0.0.0.0 \
-  --ip-whitelist ~/.config/tlsrouter/ip-whitelist.csv \
-  --ip-blacklist-dir ~/.local/share/bitwire-it/ipblocklist \
-  --ip-blacklist-repo https://github.com/ORG/ipblocklist.git"
-ssh TARGET_HOST "rm -rf /tmp/test-blocklist /tmp/test-blocklist-clone /tmp/test-ip-whitelist.csv"
+./skills/tlsrouter-deploy-test/scripts/test-acme-reachability.sh TARGET_HOST TARGET_DOMAIN REACHABLE_IP UNREACHABLE_IP
 ```
 
-VERIFY: production service healthy
-```sh
-curl -sS --connect-timeout 3 https://TARGET_DOMAIN/api/version
-```
+Where:
+- REACHABLE_IP: an IP within `--networks` with a running backend (e.g. 10.0.2.21)
+- UNREACHABLE_IP: an IP within `--networks` with no backend (e.g. 10.0.2.249)
 
-## 8. Test ACME reachability check
+The script also tests an IP outside allowed networks (10.249.249.249).
 
-The reachability check prevents wasted ACME attempts against unreachable backends.
-Requires `--networks` to include the target subnet and `--ip-domains` to match the SLD.
-
-### 8a. Reachable backend succeeds
-
-```sh
-curl -sS --connect-timeout 5 https://tls-10-0-2-21.TARGET_DOMAIN/ -o /dev/null -w "%{http_code}\n"
-# expect: 200 (backend is up, ACME succeeds)
-```
-
-### 8b. Unreachable backend in allowed network
-
-```sh
-curl -sS --connect-timeout 10 https://tls-10-0-2-249.TARGET_DOMAIN/ -o /dev/null -w "%{http_code}\n"
-# expect: SSL error (connection reset)
-```
-
-VERIFY: logs show `backend unreachable for ... skipping ACME`
-```sh
-ssh TARGET_HOST "sudo journalctl -u tlsrouter --since '30 sec ago' --no-pager | grep unreachable"
-```
-
-### 8c. IP outside allowed networks
-
-```sh
-curl -sS --connect-timeout 10 https://tls-10-249-249-249.TARGET_DOMAIN/ -o /dev/null -w "%{http_code}\n"
-# expect: SSL error (connection reset)
-```
-
-VERIFY: logs show `target IP not in any allowed network`
-```sh
-ssh TARGET_HOST "sudo journalctl -u tlsrouter --since '30 sec ago' --no-pager | grep 'not in any allowed'"
-```
+VERIFY: script prints all `OK` — reachable gets 200, unreachable logs show
+`backend unreachable ... skipping ACME`, outside-network logs show
+`target IP not in any allowed network`
 
 ## Notes
 

--- a/skills/tlsrouter-deploy-test/scripts/build-and-deploy.sh
+++ b/skills/tlsrouter-deploy-test/scripts/build-and-deploy.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -e
+
+# Build tlsrouter for linux/amd64 and deploy to a remote host.
+# Usage: ./scripts/build-and-deploy.sh <host>
+
+if test -z "$1"; then
+	echo "Usage: $0 <host>" >&2
+	exit 1
+fi
+
+g_host="$1"
+g_out="./agents/tmp/tlsrouter-linux-amd64"
+
+mkdir -p ./agents/tmp
+
+g_ldflags="-X main.version=$(git describe --tags --always) -X main.commit=$(git rev-parse --short HEAD) -X main.date=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+GOOS=linux GOARCH=amd64 go build -ldflags "$g_ldflags" -o "$g_out" ./cmd/tlsrouter/
+
+echo "Built: $(file "$g_out" | cut -d: -f2)"
+
+scp "$g_out" "${g_host}:~/bin/tlsrouter.new"
+ssh "$g_host" "mv ~/bin/tlsrouter.new ~/bin/tlsrouter && chmod +x ~/bin/tlsrouter"
+
+echo ""
+echo "Deployed. Remote version:"
+ssh "$g_host" "~/bin/tlsrouter --version"

--- a/skills/tlsrouter-deploy-test/scripts/test-acme-reachability.sh
+++ b/skills/tlsrouter-deploy-test/scripts/test-acme-reachability.sh
@@ -1,0 +1,91 @@
+#!/bin/sh
+set -e
+
+# Test ACME reachability check on a deployed tlsrouter host.
+# Usage: ./scripts/test-acme-reachability.sh <host> <domain> <reachable-ip> <unreachable-ip>
+#
+# Tests that reachable backends get ACME certs and unreachable ones are
+# blocked before ACME attempt. IPs must be within the configured --networks.
+
+if test -z "$4"; then
+	echo "Usage: $0 <host> <domain> <reachable-ip> <unreachable-ip>" >&2
+	echo "  host:           SSH target" >&2
+	echo "  domain:         base domain (e.g. proxy.example.com)" >&2
+	echo "  reachable-ip:   IP with a running backend (in allowed network)" >&2
+	echo "  unreachable-ip: IP with no backend (in allowed network)" >&2
+	exit 1
+fi
+
+g_host="$1"
+g_domain="$2"
+g_reachable="$3"
+g_unreachable="$4"
+
+g_reachable_dashed=$(echo "$g_reachable" | tr '.' '-')
+g_unreachable_dashed=$(echo "$g_unreachable" | tr '.' '-')
+g_pass=0
+g_fail=0
+
+echo "# ACME reachability test"
+echo "# Host: $g_host"
+echo "# Domain: $g_domain"
+echo "# Reachable: $g_reachable (tls-${g_reachable_dashed}.${g_domain})"
+echo "# Unreachable: $g_unreachable (tls-${g_unreachable_dashed}.${g_domain})"
+echo ""
+
+echo "## Reachable backend (expect 200)..."
+b_code=$(curl -sS --connect-timeout 15 -o /dev/null -w "%{http_code}" "https://tls-${g_reachable_dashed}.${g_domain}/" 2> /dev/null || echo "000")
+if test "$b_code" = "200"; then
+	echo "OK  tls-${g_reachable_dashed}: $b_code"
+	g_pass=$((g_pass + 1))
+else
+	echo "FAIL  tls-${g_reachable_dashed}: got $b_code, expected 200"
+	g_fail=$((g_fail + 1))
+fi
+
+echo ""
+echo "## Unreachable backend in allowed network (expect SSL error)..."
+b_code=$(curl -sS --connect-timeout 10 -o /dev/null -w "%{http_code}" "https://tls-${g_unreachable_dashed}.${g_domain}/" 2> /dev/null || echo "000")
+if test "$b_code" = "000"; then
+	echo "OK  tls-${g_unreachable_dashed}: connection failed (expected)"
+	g_pass=$((g_pass + 1))
+else
+	echo "FAIL  tls-${g_unreachable_dashed}: got $b_code, expected connection failure"
+	g_fail=$((g_fail + 1))
+fi
+
+b_log=$(ssh "$g_host" "sudo journalctl -u tlsrouter --since '30 sec ago' --no-pager 2>/dev/null | grep 'unreachable' | head -1")
+if echo "$b_log" | grep -q "unreachable"; then
+	echo "OK  log confirms: backend unreachable, skipping ACME"
+	g_pass=$((g_pass + 1))
+else
+	echo "FAIL  no 'unreachable' log found"
+	g_fail=$((g_fail + 1))
+fi
+
+echo ""
+echo "## IP outside allowed networks (expect SSL error)..."
+b_code=$(curl -sS --connect-timeout 10 -o /dev/null -w "%{http_code}" "https://tls-10-249-249-249.${g_domain}/" 2> /dev/null || echo "000")
+if test "$b_code" = "000"; then
+	echo "OK  tls-10-249-249-249: connection failed (expected)"
+	g_pass=$((g_pass + 1))
+else
+	echo "FAIL  tls-10-249-249-249: got $b_code, expected connection failure"
+	g_fail=$((g_fail + 1))
+fi
+
+b_log=$(ssh "$g_host" "sudo journalctl -u tlsrouter --since '30 sec ago' --no-pager 2>/dev/null | grep 'not in any allowed' | head -1")
+if echo "$b_log" | grep -q "not in any allowed"; then
+	echo "OK  log confirms: target IP not in any allowed network"
+	g_pass=$((g_pass + 1))
+else
+	echo "FAIL  no 'not in any allowed' log found"
+	g_fail=$((g_fail + 1))
+fi
+
+echo ""
+echo "Results: $g_pass passed, $g_fail failed"
+
+if test "$g_fail" -gt 0; then
+	exit 1
+fi

--- a/skills/tlsrouter-deploy-test/scripts/test-health.sh
+++ b/skills/tlsrouter-deploy-test/scripts/test-health.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+set -e
+
+# Test tlsrouter service health on a deployed host.
+# Usage: ./scripts/test-health.sh <domain>
+
+if test -z "$1"; then
+	echo "Usage: $0 <domain>" >&2
+	exit 1
+fi
+
+g_domain="$1"
+g_pass=0
+g_fail=0
+
+check() {
+	b_label="$1"
+	b_expect="$2"
+	b_url="$3"
+	b_code=$(curl -sS --connect-timeout 3 -o /dev/null -w "%{http_code}" "$b_url" 2> /dev/null || echo "000")
+
+	if test "$b_code" = "$b_expect"; then
+		echo "OK  $b_label: $b_code"
+		g_pass=$((g_pass + 1))
+	else
+		echo "FAIL  $b_label: got $b_code, expected $b_expect"
+		g_fail=$((g_fail + 1))
+	fi
+}
+
+echo "# Health checks for $g_domain"
+echo ""
+
+check "HTTPS reachable" "200" "https://${g_domain}/version"
+check "HTTP redirect" "301" "http://${g_domain}/"
+
+echo ""
+echo "Results: $g_pass passed, $g_fail failed"
+
+if test "$g_fail" -gt 0; then
+	exit 1
+fi

--- a/skills/tlsrouter-deploy-test/scripts/test-ip-filtering.sh
+++ b/skills/tlsrouter-deploy-test/scripts/test-ip-filtering.sh
@@ -1,0 +1,82 @@
+#!/bin/sh
+set -e
+
+# Test IP filtering on a deployed tlsrouter host.
+# Usage: ./scripts/test-ip-filtering.sh <host> <domain> <test-ip>
+#
+# Requires: the test-ip to be your current public IP (or an IP you can
+# connect from). Creates a local git blocklist repo, reconfigures the
+# service to use it, verifies rejection, then restores production config.
+
+if test -z "$3"; then
+	echo "Usage: $0 <host> <domain> <test-ip>" >&2
+	echo "  host:    SSH target (e.g. deploy.example.com)" >&2
+	echo "  domain:  TLS domain to test against" >&2
+	echo "  test-ip: IP to add to blocklist (your public IP)" >&2
+	exit 1
+fi
+
+g_host="$1"
+g_domain="$2"
+g_test_ip="$3"
+
+echo "# IP filtering test"
+echo "# Host: $g_host"
+echo "# Domain: $g_domain"
+echo "# Test IP: $g_test_ip"
+echo ""
+
+echo "## Creating test blocklist repo on $g_host..."
+ssh "$g_host" "rm -rf /tmp/test-blocklist /tmp/test-blocklist-clone && \
+  mkdir -p /tmp/test-blocklist/tables/inbound && \
+  cd /tmp/test-blocklist && git init && \
+  git config user.email 'test@test.com' && git config user.name 'test' && \
+  echo '$g_test_ip' > tables/inbound/single_ips.txt && \
+  touch tables/inbound/networks.txt && \
+  git add -A && git commit -m 'test blocklist'" > /dev/null 2>&1
+echo "OK  blocklist repo created with $g_test_ip"
+
+echo ""
+echo "## Reconfiguring service to use test blocklist..."
+echo "   (save current ExecStart first)"
+g_old_exec=$(ssh "$g_host" "grep '^ExecStart=' /etc/systemd/system/tlsrouter.service")
+echo "   saved: ${g_old_exec}"
+
+ssh "$g_host" "~/.local/bin/serviceman add --daemon --name tlsrouter -- \
+  ~/bin/tlsrouter \
+  --ip-domains $g_domain \
+  --networks 10.0.0.0/8 \
+  --config ~/.config/tlsrouter/backends.csv \
+  --vault ~/.config/tlsrouter/secrets.tsv \
+  --bind 0.0.0.0 \
+  --ip-whitelist /tmp/test-ip-whitelist.csv \
+  --ip-blacklist-dir /tmp/test-blocklist-clone \
+  --ip-blacklist-repo file:///tmp/test-blocklist" > /dev/null 2>&1
+
+echo "   waiting for blocklist to load..."
+sleep 4
+
+echo ""
+echo "## Testing blocklist rejection..."
+b_code=$(curl -sS --connect-timeout 5 -o /dev/null -w "%{http_code}" "https://${g_domain}/version" 2> /dev/null || echo "000")
+if test "$b_code" = "000"; then
+	echo "OK  connection rejected (code: $b_code)"
+else
+	echo "FAIL  expected rejection, got HTTP $b_code"
+fi
+
+b_log=$(ssh "$g_host" "sudo journalctl -u tlsrouter --since '30 sec ago' --no-pager 2>/dev/null | grep 'rejected' | head -1")
+if echo "$b_log" | grep -q "rejected"; then
+	echo "OK  log confirms: $b_log"
+else
+	echo "WARN  no rejection log found"
+fi
+
+echo ""
+echo "## Cleanup: restoring production config..."
+ssh "$g_host" "rm -rf /tmp/test-blocklist /tmp/test-blocklist-clone /tmp/test-ip-whitelist.csv"
+
+echo ""
+echo "MUST: Restore production config with serviceman now."
+echo "The previous ExecStart was:"
+echo "  $g_old_exec"


### PR DESCRIPTION
## Summary

- TCP dial check (2s timeout) to backend port and SSH before calling ManageSync
- Prevents wasting ACME attempts against unreachable backends
- Introduces `errIPNotInNetwork` sentinel so route resolution errors are specific
- Improves error message for failed CNAME/SRV lookups (includes domain name)

## Tested on deploy target

| Test case | Domain pattern | Result |
|-----------|---------------|--------|
| Reachable backend | `tls-10-0-2-21.proxy.example.com` | ACME cert obtained, proxied to backend:3080, 200 |
| Unreachable backend (in allowed network) | `tls-10-0-2-249.proxy.example.com` | `backend unreachable ... skipping ACME`, no cert issued |
| IP outside allowed networks | `tls-10-249-249-249.proxy.example.com` | `target IP not in any allowed network; also no matching CNAME or SRV record` |

## Changes

- `dynamic-config.go`: add `checkBackendReachable()`, `errIPNotInNetwork` sentinel, restructure `resolveRoute()` to produce combined errors
- `skills/tlsrouter-deploy-test/SKILL.md`: add ACME reachability test procedure

## Test plan

- [x] Reachable backend obtains ACME cert and proxies successfully
- [x] Unreachable backend in allowed network blocked before ACME attempt
- [x] IP outside allowed networks rejected at route resolution with clear error
- [x] Existing dynamic routing (CNAME/SRV) unaffected