### PR TITLE
feat(cli): default config/vault to ~/.config/tlsrouter/

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A TLS Reverse Proxy for SNI and ALPN routing.
 Supports both static and dynamic TLS routing.
 
 ```sh
-go run ./cmd/tlsrouter/ \
+tlsrouter \
    --config ~/.config/tlsrouter/backends.csv \
    --vault ~/.config/tlsrouter/secrets.tsv \
    --ip-domains vm.example.com \
@@ -16,6 +16,30 @@ go run ./cmd/tlsrouter/ \
 
 Configured backends are loaded statically, while URLs like <https://tls-192-168-1-100.vm.example.com> are dynamically proxied -
 provided that the ip domain and ip-as-subdomain addresses match the allowed domain and networks.
+
+- `--config` — Path to backends config CSV file (default: `~/.config/tlsrouter/backends.csv`)
+- `--vault` — Path to vault TSV file (default: `~/.config/tlsrouter/secrets.tsv`)
+- `--ip-domains` — Comma-separated base domains for dynamic IP URLs (default: `example.localdomain`)
+- `--networks` — Allowed networks for dynamic IP proxying (default: `169.254.0.0/16`)
+- `--bind` — Address to bind to (default: `0.0.0.0`)
+- `--port` — TLS port to listen on; `-1` to disable (default: `443`)
+- `--plain-port` — Plain HTTP port for redirects; `-1` to disable (default: `80`)
+
+## Environment Variables
+
+All flags can be set via environment variables (flags take precedence):
+
+| Flag | Env Var | Default |
+| :--- | :------ | :------ |
+| `--port` | `PORT` | `443` |
+| `--plain-port` | `PLAIN_PORT` | `80` |
+| `--bind` | `BIND` | `0.0.0.0` |
+| `--config` | `CONFIG_FILE` | `~/.config/tlsrouter/backends.csv` |
+| `--vault` | `VAULT_FILE` | `~/.config/tlsrouter/secrets.tsv` |
+| `--ip-domains` | `DYNAMIC_IP_DOMAIN` | `example.localdomain` |
+| `--networks` | `DYNAMIC_HOST_NETWORKS` | `169.254.0.0/16` |
+
+A `.env` file in the working directory is loaded automatically.
 
 ## DNS Authorization
 

--- a/cmd/tlsrouter/main.go
+++ b/cmd/tlsrouter/main.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"slices"
 	"strconv"
 	"strings"
@@ -95,8 +96,8 @@ func main() {
 	fs.IntVar(&cfg.port, "port", envOrInt("PORT", 443), "TLS port to listen on. -1 to disable.")
 	fs.IntVar(&cfg.plainPort, "plain-port", envOrInt("PLAIN_PORT", 80), "Plain (HTTP) port to listen on (for redirects). -1 to disable.")
 	fs.StringVar(&cfg.bind, "bind", cmp.Or(os.Getenv("BIND"), "0.0.0.0"), "Address to bind to")
-	fs.StringVar(&cfg.confPath, "config", cmp.Or(os.Getenv("CONFIG_FILE"), "backends.csv"), "Path to backends config CSV file")
-	fs.StringVar(&cfg.vaultPath, "vault", cmp.Or(os.Getenv("VAULT_FILE"), "secrets.tsv"), "Path to vault TSV file")
+	fs.StringVar(&cfg.confPath, "config", cmp.Or(os.Getenv("CONFIG_FILE"), filepath.Join(defaultConfigDir(), "backends.csv")), "Path to backends config CSV file")
+	fs.StringVar(&cfg.vaultPath, "vault", cmp.Or(os.Getenv("VAULT_FILE"), filepath.Join(defaultConfigDir(), "secrets.tsv")), "Path to vault TSV file")
 
 	fs.Usage = func() {
 		printVersion()
@@ -230,6 +231,15 @@ func main() {
 	}()
 
 	wg.Wait()
+}
+
+func defaultConfigDir() string {
+	configHome := os.Getenv("XDG_CONFIG_HOME")
+	if configHome == "" {
+		home, _ := os.UserHomeDir()
+		configHome = filepath.Join(home, ".config")
+	}
+	return filepath.Join(configHome, "tlsrouter")
 }
 
 func envOrInt(key string, fallback int) int {


### PR DESCRIPTION
## Summary
- Default `--config` and `--vault` paths to `~/.config/tlsrouter/` (respects `XDG_CONFIG_HOME`)
- Add `defaultConfigDir()` helper
- Document all CLI flags with defaults in README
- Add environment variables reference table to README

## Test plan
- [x] `go build ./cmd/tlsrouter/` compiles
- [x] `go run ./cmd/tlsrouter/ --help` shows `~/.config/tlsrouter/backends.csv` and `secrets.tsv` as defaults