### PR TITLE
feat(auth): support multiple tokens per vault entry

### DIFF
--- a/cmd/tabvault/main.go
+++ b/cmd/tabvault/main.go
@@ -15,7 +15,7 @@ import (
 func main() {
 	mainFlags := flag.NewFlagSet("", flag.ContinueOnError)
 	mainFlags.Usage = func() {
-		fmt.Println("Usage:\ntouch ./path/to/secrets.tsv\ntabvault ./path/to/secrets.tsv new\ntabvault ./path/to/secrets.tsv add < ./secret.txt\ntabvault ./path/to/secrets.tsv verify <vault-id> < ./password.txt")
+		fmt.Println("Usage:\ntouch ./path/to/secrets.tsv\ntabvault ./path/to/secrets.tsv new\ntabvault ./path/to/secrets.tsv add < ./secret.txt\ntabvault ./path/to/secrets.tsv append <vault-id> < ./token.txt\ntabvault ./path/to/secrets.tsv verify <vault-id> < ./password.txt")
 		mainFlags.PrintDefaults()
 	}
 	if err := mainFlags.Parse(os.Args[1:]); err != nil {
@@ -48,6 +48,18 @@ func main() {
 		fmt.Println(secret)
 	case "add":
 		secret = readSecret()
+	case "append":
+		if len(args) < 3 {
+			fmt.Fprintln(os.Stderr, "Usage: tabvault <vault-file> append <vault-id>")
+			os.Exit(1)
+		}
+		token := readSecret()
+		if err := tabVault.AppendToken(args[2], token); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %s\n", err)
+			os.Exit(1)
+		}
+		fmt.Fprintln(os.Stderr, "OK")
+		os.Exit(0)
 	case "verify":
 		if len(args) < 3 {
 			fmt.Fprintln(os.Stderr, "Usage: tabvault <vault-file> verify <vault-id>")

--- a/tabvault/tabvault.go
+++ b/tabvault/tabvault.go
@@ -137,6 +137,44 @@ func (v *TabVault) Add(secret string) (string, error) {
 	return id, file.Close()
 }
 
+var ErrNotFound = errors.New("vault entry not found")
+
+func (v *TabVault) AppendToken(id string, token string) error {
+	id = strings.TrimPrefix(id, "vault://")
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	existing, ok := v.secrets[id]
+	if !ok {
+		return ErrNotFound
+	}
+
+	v.secrets[id] = existing + " " + token
+
+	return v.rewrite()
+}
+
+func (v *TabVault) rewrite() error {
+	file, err := os.Create(v.filepath)
+	if err != nil {
+		return err
+	}
+
+	writer := csv.NewWriter(file)
+	writer.Comma = '\t'
+	_ = writer.Write([]string{"vault_id", "vault_secret"})
+	for id, secret := range v.secrets {
+		_ = writer.Write([]string{id, secret})
+	}
+	writer.Flush()
+
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		return err
+	}
+	return file.Close()
+}
+
 func (v *TabVault) Get(id string) string {
 	v.mu.RLock()
 	defer v.mu.RUnlock()
@@ -163,6 +201,19 @@ func (v *TabVault) Verify(id string, password string) error {
 		return ErrInvalidCredentials
 	}
 
+	for token := range strings.SplitSeq(secret, " ") {
+		token = strings.TrimSpace(token)
+		if token == "" {
+			continue
+		}
+		if verifyOne(token, password) == nil {
+			return nil
+		}
+	}
+	return ErrInvalidCredentials
+}
+
+func verifyOne(secret, password string) error {
 	if !strings.HasPrefix(secret, phcPrefix) {
 		return BasicAuthPassword(secret).Verify("", password)
 	}


### PR DESCRIPTION
## Summary

- Split `Verify` into per-token `verifyOne` helper; vault entries can now hold multiple space-separated tokens
- Added `AppendToken` method and `rewrite` helper to tabvault package
- Added `append` subcommand to `cmd/tabvault` CLI for adding tokens to existing entries

## Usage

```sh
# Create a new vault entry
tabvault secrets.tsv new

# Append a second token to an existing entry
echo "new-token" | tabvault secrets.tsv append <vault-id>

# Verify any token in the entry
echo "new-token" | tabvault secrets.tsv verify <vault-id>
```

## Test plan

- [x] Auth-gated endpoint returns 401 without credentials
- [x] Auth-gated endpoint returns 302 with existing token
- [x] `tabvault append <id>` appends token to existing entry
- [x] After restart, new plaintext token authenticates (302)
- [x] Original PHC tokens still valid after append
- [x] Invalid tokens still rejected (401)
- [x] `tabvault verify <id>` works with appended token
- [x] Vault restored to production state after testing