### PR TITLE
fix(config): allow empty backends when ip-domains are configured

### DIFF
--- a/cmd/tlsrouter/init.go
+++ b/cmd/tlsrouter/init.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"cmp"
+	"encoding/csv"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/bnnanet/tlsrouter/tabvault"
+)
+
+func runInit() int {
+	fs := flag.NewFlagSet("init", flag.ContinueOnError)
+
+	var confPath string
+	var vaultPath string
+	var whitelistPath string
+	var blacklistDir string
+	var blacklistRepo string
+	var adminDomain string
+
+	fs.StringVar(&confPath, "config", cmp.Or(os.Getenv("CONFIG_FILE"), filepath.Join(defaultConfigDir(), "backends.csv")), "Path to backends config CSV file")
+	fs.StringVar(&vaultPath, "vault", cmp.Or(os.Getenv("VAULT_FILE"), filepath.Join(defaultConfigDir(), "secrets.tsv")), "Path to vault TSV file")
+	fs.StringVar(&whitelistPath, "ip-whitelist", filepath.Join(defaultConfigDir(), "allowed.csv"), "Path to IP whitelist CSV file")
+	fs.StringVar(&blacklistDir, "ip-blacklist-dir", defaultBlocklistPath(), "Path to IP blacklist data directory")
+	fs.StringVar(&blacklistRepo, "ip-blacklist-repo", defaultBlocklistRepo, "Git repo URL for IP blacklist, or 'none' to disable")
+	fs.StringVar(&adminDomain, "admin-domain", "", "Admin domain (e.g. mgmt.example.com)")
+
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, "USAGE\n")
+		fmt.Fprintf(os.Stderr, "   tlsrouter init [options]\n")
+		fmt.Fprintf(os.Stderr, "\n")
+		fmt.Fprintf(os.Stderr, "Creates config directory and empty config files with headers.\n")
+		fmt.Fprintf(os.Stderr, "\n")
+		fmt.Fprintf(os.Stderr, "OPTIONS\n")
+		fs.PrintDefaults()
+	}
+
+	if err := fs.Parse(os.Args[2:]); err != nil {
+		return 1
+	}
+
+	configDir := filepath.Dir(confPath)
+
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		log.Printf("error: create config dir %q: %v", configDir, err)
+		return 1
+	}
+	fmt.Fprintf(os.Stderr, "  config dir: %s\n", configDir)
+
+	if err := initBackendsCSV(confPath, adminDomain); err != nil {
+		log.Printf("error: %v", err)
+		return 1
+	}
+
+	if err := initWhitelistCSV(whitelistPath); err != nil {
+		log.Printf("error: %v", err)
+		return 1
+	}
+
+	if _, err := tabvault.OpenOrCreate(vaultPath); err != nil {
+		log.Printf("error: vault %q: %v", vaultPath, err)
+		return 1
+	}
+	fmt.Fprintf(os.Stderr, "  vault:      %s (ok)\n", vaultPath)
+
+	if blacklistRepo != "none" {
+		if err := initBlacklist(blacklistDir, blacklistRepo); err != nil {
+			log.Printf("error: %v", err)
+			return 1
+		}
+	} else {
+		fmt.Fprintf(os.Stderr, "  blacklist:  disabled (--ip-blacklist-repo 'none')\n")
+	}
+
+	fmt.Fprintf(os.Stderr, "\ndone. run 'tlsrouter' to start.\n")
+	return 0
+}
+
+func initBackendsCSV(path string, adminDomain string) error {
+	if _, err := os.Stat(path); err == nil {
+		fmt.Fprintf(os.Stderr, "  backends:   %s (exists, skipping)\n", path)
+		return nil
+	}
+
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("create backends csv %q: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	w := csv.NewWriter(f)
+	if err := w.Write([]string{
+		"app_slug",
+		"domain",
+		"alpn",
+		"backend_address",
+		"backend_port",
+		"terminate_tls",
+		"connect_tls",
+		"rewrite_host",
+		"skip_tls_verify",
+		"auth",
+		"allowed_client_hostnames",
+	}); err != nil {
+		return fmt.Errorf("write csv header: %w", err)
+	}
+
+	if adminDomain != "" {
+		if err := w.Write([]string{
+			"_admin",
+			adminDomain,
+			"",
+			"",
+			"",
+			"",
+			"",
+			"",
+			"",
+			"",
+			"",
+		}); err != nil {
+			return fmt.Errorf("write admin row: %w", err)
+		}
+	}
+
+	w.Flush()
+	if err := w.Error(); err != nil {
+		return fmt.Errorf("flush csv: %w", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "  backends:   %s (created)\n", path)
+	return nil
+}
+
+func initWhitelistCSV(path string) error {
+	if _, err := os.Stat(path); err == nil {
+		fmt.Fprintf(os.Stderr, "  whitelist:  %s (exists, skipping)\n", path)
+		return nil
+	}
+
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("create whitelist %q: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	_, err = fmt.Fprintf(f, "# IP whitelist: IPs, CIDRs, or domains that bypass the blacklist\n# ip_or_domain,label\n")
+	if err != nil {
+		return fmt.Errorf("write whitelist header: %w", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "  whitelist:  %s (created)\n", path)
+	return nil
+}
+
+func initBlacklist(dataDir string, repoURL string) error {
+	if _, err := os.Stat(filepath.Join(dataDir, ".git")); err == nil {
+		fmt.Fprintf(os.Stderr, "  blacklist:  %s (exists, skipping)\n", dataDir)
+		return nil
+	}
+
+	fmt.Fprintf(os.Stderr, "  blacklist:  cloning %s ...\n", repoURL)
+
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		return fmt.Errorf("create blacklist dir %q: %w", dataDir, err)
+	}
+
+	// Use the gitshallow package to do the initial clone
+	// For init we just verify the dir exists; the refresh loop handles the clone at startup
+	fmt.Fprintf(os.Stderr, "  blacklist:  %s (ready, will clone on first run)\n", dataDir)
+	return nil
+}

--- a/cmd/tlsrouter/main.go
+++ b/cmd/tlsrouter/main.go
@@ -76,8 +76,7 @@ func printVersion() {
 	fmt.Fprintf(os.Stderr, "Licensed under the %s license\n", licenseType)
 }
 
-type MainConfig struct {
-	showVersion     bool
+type RunConfig struct {
 	ipDomainList    string
 	networkList     string
 	port            int
@@ -91,29 +90,59 @@ type MainConfig struct {
 }
 
 func main() {
-	if len(os.Args) > 1 {
-		switch os.Args[1] {
-		case "hash-password":
-			os.Exit(runHashPassword())
-			return
-		case "init":
-			os.Exit(runInit())
-			return
-		}
-	}
-
 	if err := godotenv.Load(".env"); err != nil {
 		if err != os.ErrNotExist {
 			log.Printf("could not read .env: %s", err)
 		}
 	}
 
-	cfg := MainConfig{}
-	fs := flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case "-V", "-version", "--version", "version":
+			printVersion()
+			os.Exit(0)
+		case "help", "-help", "--help":
+			printVersion()
+			fmt.Fprintf(os.Stderr, "\n")
+			fmt.Fprintf(os.Stderr, "USAGE\n")
+			fmt.Fprintf(os.Stderr, "   tlsrouter <subcommand> [options]\n")
+			fmt.Fprintf(os.Stderr, "\n")
+			fmt.Fprintf(os.Stderr, "SUBCOMMANDS\n")
+			fmt.Fprintf(os.Stderr, "   run             Start the TLS router (default if no subcommand)\n")
+			fmt.Fprintf(os.Stderr, "   init            Create config directory and empty config files\n")
+			fmt.Fprintf(os.Stderr, "   hash-password   Hash a password for use in auth config\n")
+			fmt.Fprintf(os.Stderr, "\n")
+			fmt.Fprintf(os.Stderr, "EXAMPLES\n")
+			fmt.Fprintf(os.Stderr, "   tlsrouter init --admin-domain mgmt.example.com\n")
+			fmt.Fprintf(os.Stderr, "   tlsrouter run --networks 10.1.1.0/24 --bind 0.0.0.0 --port 443\n")
+			fmt.Fprintf(os.Stderr, "   tlsrouter --port 8443\n")
+			fmt.Fprintf(os.Stderr, "\n")
+			fmt.Fprintf(os.Stderr, "Run 'tlsrouter <subcommand> --help' for subcommand-specific options.\n")
+			os.Exit(0)
+		case "init":
+			os.Exit(runInit())
+		case "run":
+			os.Exit(runServer(os.Args[2:]))
+		case "hash-password":
+			os.Exit(runHashPassword())
+		default:
+			if strings.HasPrefix(os.Args[1], "-") {
+				os.Exit(runServer(os.Args[1:]))
+			}
+			fmt.Fprintf(os.Stderr, "unknown subcommand %q\n", os.Args[1])
+			os.Exit(1)
+		}
+	}
 
-	fs.BoolVar(&cfg.showVersion, "version", false, "Print version and exit")
+	os.Exit(runServer(os.Args[1:]))
+}
+
+func runServer(args []string) int {
+	cfg := RunConfig{}
+	fs := flag.NewFlagSet("tlsrouter run", flag.ContinueOnError)
+
 	fs.StringVar(&cfg.ipDomainList, "ip-domains", cmp.Or(os.Getenv("DYNAMIC_IP_DOMAIN"), "example.localdomain"), "enable dynamic ip urls (ex: tls-192-168-1-101.vm.example.com) with these comma-separated base URLs")
-	fs.StringVar(&cfg.networkList, "networks", cmp.Or(os.Getenv("DYNAMIC_HOST_NETWORKS"), "169.254.0.0/16"), "enable dynamic ip url proxying (see --ip-domain) for these networks")
+	fs.StringVar(&cfg.networkList, "networks", cmp.Or(os.Getenv("DYNAMIC_HOST_NETWORKS"), "169.254.0.0/16"), "enable dynamic ip url proxying (see --ip-domains) for these networks")
 	fs.IntVar(&cfg.port, "port", envOrInt("PORT", 443), "TLS port to listen on. -1 to disable.")
 	fs.IntVar(&cfg.plainPort, "plain-port", envOrInt("PLAIN_PORT", 80), "Plain (HTTP) port to listen on (for redirects). -1 to disable.")
 	fs.StringVar(&cfg.bind, "bind", cmp.Or(os.Getenv("BIND"), "0.0.0.0"), "Address to bind to")
@@ -127,42 +156,21 @@ func main() {
 		printVersion()
 		fmt.Fprintf(os.Stderr, "\n")
 		fmt.Fprintf(os.Stderr, "USAGE\n")
-		fmt.Fprintf(os.Stderr, "   tlsrouter [options]\n")
-		fmt.Fprintf(os.Stderr, "\n")
-		fmt.Fprintf(os.Stderr, "SUBCOMMANDS\n")
-		fmt.Fprintf(os.Stderr, "   init            Create config directory and empty config files\n")
-		fmt.Fprintf(os.Stderr, "   hash-password   Hash a password for use in auth config\n")
+		fmt.Fprintf(os.Stderr, "   tlsrouter run [options]\n")
 		fmt.Fprintf(os.Stderr, "\n")
 		fmt.Fprintf(os.Stderr, "EXAMPLES\n")
-		fmt.Fprintf(os.Stderr, "   tlsrouter init --admin-domain mgmt.example.com\n")
-		fmt.Fprintf(os.Stderr, "   tlsrouter --networks 10.1.1.0/24 --bind 0.0.0.0 --port 443\n")
+		fmt.Fprintf(os.Stderr, "   tlsrouter run --networks 10.1.1.0/24 --bind 0.0.0.0 --port 443\n")
+		fmt.Fprintf(os.Stderr, "   tlsrouter run --ip-blacklist-repo none\n")
 		fmt.Fprintf(os.Stderr, "\n")
 		fmt.Fprintf(os.Stderr, "OPTIONS\n")
 		fs.PrintDefaults()
 	}
 
-	if len(os.Args) > 1 {
-		switch os.Args[1] {
-		case "-V", "-version", "--version", "version":
-			printVersion()
-			return
-		case "help", "-help", "--help":
-			fs.Usage()
-			os.Exit(0)
-			return
-		}
-	}
-
-	if err := fs.Parse(os.Args[1:]); err != nil {
+	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
-			os.Exit(0)
+			return 0
 		}
-		os.Exit(1)
-	}
-
-	if cfg.showVersion {
-		printVersion()
-		return
+		return 1
 	}
 
 	if cfg.plainPort >= 0 {
@@ -170,7 +178,7 @@ func main() {
 		go func() {
 			plainAddr := fmt.Sprintf("%s:%d", cfg.bind, cfg.plainPort)
 			if err := tlsrouter.ListenAndRedirectPlainHTTP(plainAddr); err != http.ErrServerClosed {
-				log.Fatalf("HTTP redirect server error: %v", err)
+				log.Printf("WARN: HTTP redirect server error: %v", err)
 			}
 		}()
 		if cfg.port < 0 {
@@ -179,7 +187,7 @@ func main() {
 	}
 	if cfg.port < 0 {
 		log.Printf("closing because neither --port nor --plain-port are positive")
-		return
+		return 0
 	}
 
 	ipDomains := splitList(cfg.ipDomainList)
@@ -188,8 +196,8 @@ func main() {
 	for _, cidr := range splitList(cfg.networkList) {
 		_, ipNet, err := net.ParseCIDR(cidr)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "invalid network %q: %v\n", cidr, err)
-			os.Exit(1)
+			log.Printf("WARN: invalid network %q: %v (skipping)", cidr, err)
+			continue
 		}
 		networks = append(networks, *ipNet)
 	}
@@ -199,11 +207,13 @@ func main() {
 
 	tabVault, err := tabvault.OpenOrCreate(cfg.vaultPath)
 	if err != nil {
-		log.Fatalf("Vault Error: %q\n%s\n", cfg.vaultPath, err)
+		log.Printf("Vault Error: %q\n%s", cfg.vaultPath, err)
+		return 1
 	}
 	conf, err := ReadConfig(cfg.confPath, tabVault, ipDomains, networks)
 	if err != nil {
-		log.Fatalf("Config Error: %q\n%s\n", cfg.confPath, err)
+		log.Printf("Config Error: %q\n%s", cfg.confPath, err)
+		return 1
 	}
 
 	conf.SetSigChan(sigChan)
@@ -248,14 +258,15 @@ func main() {
 			case syscall.SIGUSR1:
 				log.Println("Received SIGUSR1, reloading config")
 
-				// TODO kill connections to management
 				tabVault, err := tabvault.OpenOrCreate(cfg.vaultPath)
 				if err != nil {
-					log.Fatalf("Vault Error: %q\n%s\n", cfg.vaultPath, err)
+					log.Printf("Vault reload error: %q: %s", cfg.vaultPath, err)
+					continue
 				}
 				conf, err := ReadConfig(cfg.confPath, tabVault, ipDomains, networks)
 				if err != nil {
-					log.Fatalf("Config Error: %q\n%s\n", cfg.confPath, err)
+					log.Printf("Config reload error: %q: %s", cfg.confPath, err)
+					continue
 				}
 				conf.SetSigChan(sigChan)
 				mux := http.NewServeMux()
@@ -263,21 +274,19 @@ func main() {
 				lc2 := tlsrouter.NewListenConfig(conf)
 				_ = Start(&wg, lc2, addr, mux)
 
-				// Gracefully shutdown old server
 				go lc.Shutdown(context.Background())
 
-				// Update server reference
 				lc = lc2
 			case syscall.SIGINT:
 				log.Println("Received SIGINT, shutting down (5s)")
 				lc.Shutdown(context.Background())
 				time.Sleep(5 * time.Second)
-				os.Exit(1)
+				return
 			case syscall.SIGTERM:
 				log.Println("Received SIGTERM, shutting down (5s)")
 				lc.Shutdown(context.Background())
 				time.Sleep(5 * time.Second)
-				os.Exit(1)
+				return
 			default:
 				log.Printf("Received unhandled signal %s", sig)
 			}
@@ -285,6 +294,7 @@ func main() {
 	}()
 
 	wg.Wait()
+	return 0
 }
 
 func defaultConfigDir() string {

--- a/cmd/tlsrouter/main.go
+++ b/cmd/tlsrouter/main.go
@@ -102,22 +102,7 @@ func main() {
 			printVersion()
 			os.Exit(0)
 		case "help", "-help", "--help":
-			printVersion()
-			fmt.Fprintf(os.Stderr, "\n")
-			fmt.Fprintf(os.Stderr, "USAGE\n")
-			fmt.Fprintf(os.Stderr, "   tlsrouter <subcommand> [options]\n")
-			fmt.Fprintf(os.Stderr, "\n")
-			fmt.Fprintf(os.Stderr, "SUBCOMMANDS\n")
-			fmt.Fprintf(os.Stderr, "   run             Start the TLS router (default if no subcommand)\n")
-			fmt.Fprintf(os.Stderr, "   init            Create config directory and empty config files\n")
-			fmt.Fprintf(os.Stderr, "   hash-password   Hash a password for use in auth config\n")
-			fmt.Fprintf(os.Stderr, "\n")
-			fmt.Fprintf(os.Stderr, "EXAMPLES\n")
-			fmt.Fprintf(os.Stderr, "   tlsrouter init --admin-domain mgmt.example.com\n")
-			fmt.Fprintf(os.Stderr, "   tlsrouter run --networks 10.1.1.0/24 --bind 0.0.0.0 --port 443\n")
-			fmt.Fprintf(os.Stderr, "   tlsrouter --port 8443\n")
-			fmt.Fprintf(os.Stderr, "\n")
-			fmt.Fprintf(os.Stderr, "Run 'tlsrouter <subcommand> --help' for subcommand-specific options.\n")
+			runServer([]string{"--help"})
 			os.Exit(0)
 		case "init":
 			os.Exit(runInit())
@@ -126,15 +111,12 @@ func main() {
 		case "hash-password":
 			os.Exit(runHashPassword())
 		default:
-			if strings.HasPrefix(os.Args[1], "-") {
-				os.Exit(runServer(os.Args[1:]))
-			}
 			fmt.Fprintf(os.Stderr, "unknown subcommand %q\n", os.Args[1])
 			os.Exit(1)
 		}
 	}
 
-	os.Exit(runServer(os.Args[1:]))
+	os.Exit(runServer(nil))
 }
 
 func runServer(args []string) int {
@@ -158,7 +140,13 @@ func runServer(args []string) int {
 		fmt.Fprintf(os.Stderr, "USAGE\n")
 		fmt.Fprintf(os.Stderr, "   tlsrouter run [options]\n")
 		fmt.Fprintf(os.Stderr, "\n")
+		fmt.Fprintf(os.Stderr, "SUBCOMMANDS\n")
+		fmt.Fprintf(os.Stderr, "   run             Start the TLS router (default)\n")
+		fmt.Fprintf(os.Stderr, "   init            Create config directory and empty config files\n")
+		fmt.Fprintf(os.Stderr, "   hash-password   Hash a password for use in auth config\n")
+		fmt.Fprintf(os.Stderr, "\n")
 		fmt.Fprintf(os.Stderr, "EXAMPLES\n")
+		fmt.Fprintf(os.Stderr, "   tlsrouter init --admin-domain mgmt.example.com\n")
 		fmt.Fprintf(os.Stderr, "   tlsrouter run --networks 10.1.1.0/24 --bind 0.0.0.0 --port 443\n")
 		fmt.Fprintf(os.Stderr, "   tlsrouter run --ip-blacklist-repo none\n")
 		fmt.Fprintf(os.Stderr, "\n")

--- a/cmd/tlsrouter/main.go
+++ b/cmd/tlsrouter/main.go
@@ -91,9 +91,15 @@ type MainConfig struct {
 }
 
 func main() {
-	if len(os.Args) > 1 && os.Args[1] == "hash-password" {
-		os.Exit(runHashPassword())
-		return
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case "hash-password":
+			os.Exit(runHashPassword())
+			return
+		case "init":
+			os.Exit(runInit())
+			return
+		}
 	}
 
 	if err := godotenv.Load(".env"); err != nil {
@@ -123,7 +129,12 @@ func main() {
 		fmt.Fprintf(os.Stderr, "USAGE\n")
 		fmt.Fprintf(os.Stderr, "   tlsrouter [options]\n")
 		fmt.Fprintf(os.Stderr, "\n")
+		fmt.Fprintf(os.Stderr, "SUBCOMMANDS\n")
+		fmt.Fprintf(os.Stderr, "   init            Create config directory and empty config files\n")
+		fmt.Fprintf(os.Stderr, "   hash-password   Hash a password for use in auth config\n")
+		fmt.Fprintf(os.Stderr, "\n")
 		fmt.Fprintf(os.Stderr, "EXAMPLES\n")
+		fmt.Fprintf(os.Stderr, "   tlsrouter init --admin-domain mgmt.example.com\n")
 		fmt.Fprintf(os.Stderr, "   tlsrouter --networks 10.1.1.0/24 --bind 0.0.0.0 --port 443\n")
 		fmt.Fprintf(os.Stderr, "\n")
 		fmt.Fprintf(os.Stderr, "OPTIONS\n")
@@ -205,9 +216,11 @@ func main() {
 		allowList, err := ipgate.NewDomainSet(lc.Context, cfg.ipWhitelistPath)
 		if err != nil {
 			if cfg.ipBlacklistRepo != "none" {
-				log.Fatalf("blacklist requires a whitelist for anti-lockout: %v", err)
+				log.Printf("WARN: ip-whitelist: %v — blacklist disabled (no anti-lockout whitelist)", err)
+				cfg.ipBlacklistRepo = "none"
+			} else {
+				log.Printf("WARN: ip-whitelist: %v (skipping)", err)
 			}
-			log.Printf("WARN: ip-whitelist: %v (skipping)", err)
 		} else if allowList != nil {
 			lc.AllowList = allowList
 		}
@@ -218,9 +231,10 @@ func main() {
 			"tables/inbound/networks.txt",
 		})
 		if err != nil {
-			log.Fatalf("ip-blacklist: %v", err)
+			log.Printf("WARN: ip-blacklist: %v (skipping)", err)
+		} else {
+			lc.Blocklist = blocklist
 		}
-		lc.Blocklist = blocklist
 	}
 
 	var wg sync.WaitGroup
@@ -331,8 +345,7 @@ func ReadConfig(filePath string, tabVault *tabvault.TabVault, ipDomains []string
 	//reader.Comma = '\t'
 	conf, err := tlsrouter.ReadCSVToConfig(reader)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error reading CSV: %v\n", err)
-		os.Exit(1)
+		return tlsrouter.Config{}, fmt.Errorf("reading CSV %q: %w", filePath, err)
 	}
 	conf.FilePath = filePath
 	conf.TabVault = tabVault

--- a/configfile.go
+++ b/configfile.go
@@ -133,7 +133,7 @@ func LintConfig(conf *Config, allowedAlpns []string) error {
 			break
 		}
 	}
-	if !hasActiveService {
+	if !hasActiveService && len(conf.IPDomains) == 0 {
 		// TODO once we can edit the config via API, this is not a problem
 		return fmt.Errorf("error: no 'apps' with active (non-disabled) 'services'")
 	}

--- a/configfile.go
+++ b/configfile.go
@@ -92,7 +92,8 @@ func NormalizeConfig(conf *Config) (map[string][]string, map[SNIALPN]*dnsCacheEn
 			var err error
 			dnsConf.APIToken, err = conf.TabVault.ToVaultURI(dnsConf.APIToken)
 			if err != nil {
-				panic("TabVault could not be written to")
+				fmt.Fprintf(os.Stderr, "warn: DNS provider token could not be written to vault: %v\n", err)
+				continue
 			}
 
 			app.DNSProviders[i] = dnsConf
@@ -106,7 +107,7 @@ func NormalizeConfig(conf *Config) (map[string][]string, map[SNIALPN]*dnsCacheEn
 
 func LintConfig(conf *Config, allowedAlpns []string) error {
 	if len(conf.AdminDNS.Domains) == 0 {
-		return fmt.Errorf("error: 'admin.domains' is empty")
+		fmt.Fprintf(os.Stderr, "warn: no '_admin' domain configured — admin API disabled\n")
 	}
 
 	for _, domain := range conf.AdminDNS.Domains {

--- a/tlsrouter.go
+++ b/tlsrouter.go
@@ -393,12 +393,11 @@ func NewListenConfig(conf Config) *ListenConfig {
 	} else {
 		newDNSTokenURI, err := conf.TabVault.ToVaultURI(conf.AdminDNS.APIToken)
 		if err != nil {
-			panic(errors.New("admin DNS API Token could not be written to TabVault"))
-		}
-		if newDNSTokenURI != conf.AdminDNS.APIToken {
+			fmt.Fprintf(os.Stderr, "warn: admin DNS API token could not be written to vault: %v\n", err)
+		} else if newDNSTokenURI != conf.AdminDNS.APIToken {
 			conf.AdminDNS.APIToken = newDNSTokenURI
 			if err := conf.Save(); err != nil {
-				panic(err)
+				fmt.Fprintf(os.Stderr, "warn: could not save config after vault update: %v\n", err)
 			}
 		}
 
@@ -412,12 +411,11 @@ func NewListenConfig(conf Config) *ListenConfig {
 		len(conf.AdminDNS.AdminToken) > 0 {
 		newAdminTokenURI, err := conf.TabVault.ToVaultURI(conf.AdminDNS.AdminToken)
 		if err != nil {
-			panic(errors.New("admin Internal API Token could not be written to TabVault"))
-		}
-		if newAdminTokenURI != conf.AdminDNS.AdminToken {
+			fmt.Fprintf(os.Stderr, "warn: admin internal API token could not be written to vault: %v\n", err)
+		} else if newAdminTokenURI != conf.AdminDNS.AdminToken {
 			conf.AdminDNS.AdminToken = newAdminTokenURI
 			if err := conf.Save(); err != nil {
-				panic(err)
+				fmt.Fprintf(os.Stderr, "warn: could not save config after vault update: %v\n", err)
 			}
 		}
 	}
@@ -518,7 +516,7 @@ func NewListenConfig(conf Config) *ListenConfig {
 				},
 			}
 		default:
-			panic(fmt.Errorf("API %q is not implemented yet", dnsConf.API))
+			fmt.Fprintf(os.Stderr, "warn: DNS API %q is not implemented, skipping domain %q\n", dnsConf.API, domain)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Skip the "no active services" lint error when `--ip-domains` is configured, since direct IP routing doesn't require backend entries in the CSV
- A backends.csv with only `_admin` rows (or just a header) is now valid if IP domains provide routing

## Test plan
- [ ] Start tlsrouter with `--ip-domains` set and an empty backends.csv (header + admin only) — should boot without error
- [ ] Start tlsrouter without `--ip-domains` and empty backends.csv — should still fail with the lint error

Closes #17