### PR TITLE
fix: graceful degradation for missing/broken config

### DIFF
--- a/cmd/tlsrouter/main.go
+++ b/cmd/tlsrouter/main.go
@@ -183,6 +183,11 @@ func main() {
 		networks = append(networks, *ipNet)
 	}
 
+	if len(ipDomains) > 0 && len(networks) == 0 {
+		fmt.Fprintf(os.Stderr, "error: --ip-domains requires --networks to define valid target CIDRs\n")
+		os.Exit(1)
+	}
+
 	sigChan := make(chan os.Signal, 2)
 	signal.Notify(sigChan, syscall.SIGUSR1, syscall.SIGTERM, syscall.SIGINT)
 
@@ -205,9 +210,11 @@ func main() {
 		allowList, err := ipgate.NewDomainSet(lc.Context, cfg.ipWhitelistPath)
 		if err != nil {
 			if cfg.ipBlacklistRepo != "none" {
-				log.Fatalf("blacklist requires a whitelist for anti-lockout: %v", err)
+				log.Printf("WARN: ip-whitelist: %v — blacklist disabled (no anti-lockout whitelist)", err)
+				cfg.ipBlacklistRepo = "none"
+			} else {
+				log.Printf("WARN: ip-whitelist: %v (skipping)", err)
 			}
-			log.Printf("WARN: ip-whitelist: %v (skipping)", err)
 		} else if allowList != nil {
 			lc.AllowList = allowList
 		}
@@ -218,9 +225,10 @@ func main() {
 			"tables/inbound/networks.txt",
 		})
 		if err != nil {
-			log.Fatalf("ip-blacklist: %v", err)
+			log.Printf("WARN: ip-blacklist: %v (skipping)", err)
+		} else {
+			lc.Blocklist = blocklist
 		}
-		lc.Blocklist = blocklist
 	}
 
 	var wg sync.WaitGroup
@@ -237,11 +245,13 @@ func main() {
 				// TODO kill connections to management
 				tabVault, err := tabvault.OpenOrCreate(cfg.vaultPath)
 				if err != nil {
-					log.Fatalf("Vault Error: %q\n%s\n", cfg.vaultPath, err)
+					log.Printf("WARN: reload: vault %q: %v (keeping current config)", cfg.vaultPath, err)
+					continue
 				}
 				conf, err := ReadConfig(cfg.confPath, tabVault, ipDomains, networks)
 				if err != nil {
-					log.Fatalf("Config Error: %q\n%s\n", cfg.confPath, err)
+					log.Printf("WARN: reload: config %q: %v (keeping current config)", cfg.confPath, err)
+					continue
 				}
 				conf.SetSigChan(sigChan)
 				mux := http.NewServeMux()
@@ -323,16 +333,26 @@ func Start(wg *sync.WaitGroup, lc *tlsrouter.ListenConfig, addr string, mux *htt
 func ReadConfig(filePath string, tabVault *tabvault.TabVault, ipDomains []string, networks []net.IPNet) (tlsrouter.Config, error) {
 	file, err := os.Open(filePath)
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			if len(ipDomains) == 0 {
+				return tlsrouter.Config{}, fmt.Errorf("config %q not found and no --ip-domains configured — nothing to route", filePath)
+			}
+			log.Printf("WARN: config %q not found — starting with empty config (ip-domains only)", filePath)
+			conf := &tlsrouter.Config{}
+			conf.FilePath = filePath
+			conf.TabVault = tabVault
+			conf.Networks = networks
+			conf.IPDomains = ipDomains
+			return *conf, nil
+		}
 		return tlsrouter.Config{}, err
 	}
 	defer func() { _ = file.Close() }()
 
 	reader := csv.NewReader(file)
-	//reader.Comma = '\t'
 	conf, err := tlsrouter.ReadCSVToConfig(reader)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error reading CSV: %v\n", err)
-		os.Exit(1)
+		return tlsrouter.Config{}, fmt.Errorf("reading CSV %q: %w", filePath, err)
 	}
 	conf.FilePath = filePath
 	conf.TabVault = tabVault
@@ -345,7 +365,8 @@ func ReadConfig(filePath string, tabVault *tabvault.TabVault, ipDomains []string
 
 		ips, err := net.LookupIP(domain)
 		if err != nil {
-			return tlsrouter.Config{}, err
+			log.Printf("WARN: ip-domain %q: DNS lookup failed: %v (skipping)", domain, err)
+			continue
 		}
 		for _, ip := range ips {
 			var found bool

--- a/configfile.go
+++ b/configfile.go
@@ -92,7 +92,8 @@ func NormalizeConfig(conf *Config) (map[string][]string, map[SNIALPN]*dnsCacheEn
 			var err error
 			dnsConf.APIToken, err = conf.TabVault.ToVaultURI(dnsConf.APIToken)
 			if err != nil {
-				panic("TabVault could not be written to")
+				fmt.Fprintf(os.Stderr, "warn: DNS provider token could not be written to vault: %v\n", err)
+				continue
 			}
 
 			app.DNSProviders[i] = dnsConf
@@ -106,7 +107,7 @@ func NormalizeConfig(conf *Config) (map[string][]string, map[SNIALPN]*dnsCacheEn
 
 func LintConfig(conf *Config, allowedAlpns []string) error {
 	if len(conf.AdminDNS.Domains) == 0 {
-		return fmt.Errorf("error: 'admin.domains' is empty")
+		fmt.Fprintf(os.Stderr, "warn: no '_admin' domain configured — admin API disabled\n")
 	}
 
 	for _, domain := range conf.AdminDNS.Domains {
@@ -133,7 +134,7 @@ func LintConfig(conf *Config, allowedAlpns []string) error {
 			break
 		}
 	}
-	if !hasActiveService {
+	if !hasActiveService && len(conf.IPDomains) == 0 {
 		// TODO once we can edit the config via API, this is not a problem
 		return fmt.Errorf("error: no 'apps' with active (non-disabled) 'services'")
 	}

--- a/tlsrouter.go
+++ b/tlsrouter.go
@@ -393,12 +393,11 @@ func NewListenConfig(conf Config) *ListenConfig {
 	} else {
 		newDNSTokenURI, err := conf.TabVault.ToVaultURI(conf.AdminDNS.APIToken)
 		if err != nil {
-			panic(errors.New("admin DNS API Token could not be written to TabVault"))
-		}
-		if newDNSTokenURI != conf.AdminDNS.APIToken {
+			fmt.Fprintf(os.Stderr, "warn: admin DNS API token could not be written to vault: %v\n", err)
+		} else if newDNSTokenURI != conf.AdminDNS.APIToken {
 			conf.AdminDNS.APIToken = newDNSTokenURI
 			if err := conf.Save(); err != nil {
-				panic(err)
+				fmt.Fprintf(os.Stderr, "warn: could not save config after vault update: %v\n", err)
 			}
 		}
 
@@ -412,12 +411,11 @@ func NewListenConfig(conf Config) *ListenConfig {
 		len(conf.AdminDNS.AdminToken) > 0 {
 		newAdminTokenURI, err := conf.TabVault.ToVaultURI(conf.AdminDNS.AdminToken)
 		if err != nil {
-			panic(errors.New("admin Internal API Token could not be written to TabVault"))
-		}
-		if newAdminTokenURI != conf.AdminDNS.AdminToken {
+			fmt.Fprintf(os.Stderr, "warn: admin internal API token could not be written to vault: %v\n", err)
+		} else if newAdminTokenURI != conf.AdminDNS.AdminToken {
 			conf.AdminDNS.AdminToken = newAdminTokenURI
 			if err := conf.Save(); err != nil {
-				panic(err)
+				fmt.Fprintf(os.Stderr, "warn: could not save config after vault update: %v\n", err)
 			}
 		}
 	}
@@ -518,7 +516,7 @@ func NewListenConfig(conf Config) *ListenConfig {
 				},
 			}
 		default:
-			panic(fmt.Errorf("API %q is not implemented yet", dnsConf.API))
+			fmt.Fprintf(os.Stderr, "warn: DNS API %q is not implemented, skipping domain %q\n", dnsConf.API, domain)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Allow empty backends.csv when `--ip-domains` is configured (closes #17)
- Admin domains optional — warn instead of blocking startup
- Missing whitelist disables blacklist with warning (not fatal)
- Blacklist clone/fetch failure warns and skips (not fatal)
- TabVault write failures warn instead of panicking
- Unknown DNS API warns and skips domain instead of panicking
- CSV read error returns proper error instead of `os.Exit` inside helper

## Philosophy
Unconfigured = disabled with a warning, never a crash. Optional features
(blacklist, whitelist, vault, admin API, DNS providers) can fail without
killing the main routing service.

## Test plan
- [ ] Start with empty backends.csv + `--ip-domains` set — boots without error
- [ ] Start without whitelist file, blacklist enabled — warns and skips blacklist
- [ ] Typo in DNS provider API field — warns, doesn't panic
- [ ] Missing admin domain in CSV — warns, doesn't block