### PR TITLE
fix(ipgate): skip optional CSV header in domain set

### DIFF
--- a/internal/ipgate/domains.go
+++ b/internal/ipgate/domains.go
@@ -151,6 +151,7 @@ func parseDomainSetCSV(path string) (staticPrefixes []string, domains []domainEn
 		r.Comma = '\t'
 	}
 
+	firstRow := true
 	for {
 		record, readErr := r.Read()
 		if readErr == io.EOF {
@@ -164,6 +165,17 @@ func parseDomainSetCSV(path string) (staticPrefixes []string, domains []domainEn
 		}
 
 		raw := strings.TrimSpace(record[0])
+
+		if firstRow {
+			firstRow = false
+			if _, err := netip.ParseAddr(raw); err != nil {
+				if _, err := netip.ParsePrefix(raw); err != nil {
+					if !strings.Contains(raw, ".") {
+						continue
+					}
+				}
+			}
+		}
 		if raw == "" {
 			continue
 		}

--- a/internal/ipgate/domains.go
+++ b/internal/ipgate/domains.go
@@ -5,13 +5,13 @@ import (
 	"encoding/csv"
 	"fmt"
 	"io"
-	"net"
 	"net/netip"
 	"os"
 	"strings"
 	"sync/atomic"
 	"time"
 
+	"github.com/bnnanet/tlsrouter/dnsresolver"
 	"github.com/therootcompany/golib/net/ipcohort"
 )
 
@@ -93,13 +93,11 @@ func (ds *DomainSet) resolveDomains(ctx context.Context) {
 	prev := *ds.resolved.Load()
 	next := make(map[string][]string, len(ds.domains))
 
-	resolver := &net.Resolver{}
+	resolver := dnsresolver.New()
 	for _, entry := range ds.domains {
-		resolveCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-		addrs, err := resolver.LookupHost(resolveCtx, entry.Raw)
-		cancel()
+		ips, _, err := resolver.LookupIP(ctx, entry.Raw)
 
-		if err != nil || len(addrs) == 0 {
+		if err != nil || len(ips) == 0 {
 			if old, ok := prev[entry.Raw]; ok {
 				next[entry.Raw] = old
 				fmt.Fprintf(os.Stderr, "WARN: ipgate: %s: resolve failed, keeping %d prior IPs: %v\n",
@@ -111,6 +109,10 @@ func (ds *DomainSet) resolveDomains(ctx context.Context) {
 			continue
 		}
 
+		addrs := make([]string, 0, len(ips))
+		for _, ip := range ips {
+			addrs = append(addrs, ip.String())
+		}
 		next[entry.Raw] = addrs
 	}
 


### PR DESCRIPTION
## Summary
- The `allowed.csv` parser skips the first row if it doesn't parse as an IP, CIDR, or domain (no dot)
- Uses parallel dnsresolver (miekg/dns) instead of net.Resolver — queries all nameservers simultaneously, returns first success
- Fixes spurious "resolve failed" warnings from header rows and single-nameserver timeouts

## Test plan
- [x] Deploy and confirm header-row warnings disappear from logs
- [x] Verify whitelist with header still correctly allows listed IPs/domains
- [x] Verify whitelist without header still works (first row is data)
- [x] Confirm DNS timeouts no longer occur when one nameserver is unreachable

## Test results
Deployed to production. Confirmed:
- Header row (e.g. `source,comment`) no longer triggers resolve warning
- DNS timeout errors eliminated — parallel resolver returns first success from any nameserver
- Domains with no A record still warn as expected