### PR TITLE
feat(log): structured slog logging with --verbose flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ go.work.sum
 
 # agent session files
 agents/
+LOCAL.md

--- a/api.go
+++ b/api.go
@@ -603,7 +603,7 @@ func (lc *ListenConfig) RouteCloseClients(w http.ResponseWriter, r *http.Request
 	}
 
 	snialpn := r.PathValue("Service")
-	fmt.Println("SNIALPN Query", snialpn)
+	dbg("DEBUG: SNIALPN Query %s", snialpn)
 	list, selfToClose := lc.closeClients(snialpn, r.RemoteAddr)
 
 	w.Header().Set("Content-Type", "application/json")
@@ -624,7 +624,7 @@ func (lc *ListenConfig) closeClients(snialpn string, remoteAddr string) ([]PConn
 
 	lc.Conns.Range(func(_, v any) bool {
 		wconn := v.(*wrappedConn)
-		fmt.Println("SNIALPN", wconn.SNIALPN.SNI())
+		dbg("DEBUG: SNIALPN %s", wconn.SNIALPN.SNI())
 		if snialpn == wconn.SNIALPN.SNI() || snialpn == string(wconn.SNIALPN) {
 			pconn := WConnToPConn(wconn)
 			if pconn.Address == remoteAddr {

--- a/cmd/tlsrouter/main.go
+++ b/cmd/tlsrouter/main.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"log"
+	"log/slog"
 	"net"
 	"net/http"
 	"os"
@@ -78,6 +78,7 @@ func printVersion() {
 
 type MainConfig struct {
 	showVersion     bool
+	verbose         bool
 	ipDomainList    string
 	networkList     string
 	port            int
@@ -96,9 +97,18 @@ func main() {
 		return
 	}
 
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		ReplaceAttr: func(_ []string, a slog.Attr) slog.Attr {
+			if a.Key == slog.TimeKey {
+				return slog.Attr{}
+			}
+			return a
+		},
+	})))
+
 	if err := godotenv.Load(".env"); err != nil {
 		if err != os.ErrNotExist {
-			log.Printf("could not read .env: %s", err)
+			slog.Warn("could not read .env", "err", err)
 		}
 	}
 
@@ -106,6 +116,7 @@ func main() {
 	fs := flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 
 	fs.BoolVar(&cfg.showVersion, "version", false, "Print version and exit")
+	fs.BoolVar(&cfg.verbose, "verbose", false, "Enable debug trace output")
 	fs.StringVar(&cfg.ipDomainList, "ip-domains", cmp.Or(os.Getenv("DYNAMIC_IP_DOMAIN"), "example.localdomain"), "enable dynamic ip urls (ex: tls-192-168-1-101.vm.example.com) with these comma-separated base URLs")
 	fs.StringVar(&cfg.networkList, "networks", cmp.Or(os.Getenv("DYNAMIC_HOST_NETWORKS"), "169.254.0.0/16"), "enable dynamic ip url proxying (see --ip-domain) for these networks")
 	fs.IntVar(&cfg.port, "port", envOrInt("PORT", 443), "TLS port to listen on. -1 to disable.")
@@ -154,12 +165,15 @@ func main() {
 		return
 	}
 
+	tlsrouter.Verbose = cfg.verbose
+
 	if cfg.plainPort >= 0 {
-		log.Printf("HTTP redirect listener starting on :%d → HTTPS (HTML meta)", cfg.plainPort)
+		slog.Info("HTTP redirect listener starting", "port", cfg.plainPort)
 		go func() {
 			plainAddr := fmt.Sprintf("%s:%d", cfg.bind, cfg.plainPort)
 			if err := tlsrouter.ListenAndRedirectPlainHTTP(plainAddr); err != http.ErrServerClosed {
-				log.Fatalf("HTTP redirect server error: %v", err)
+				slog.Error("HTTP redirect server failed", "err", err)
+				os.Exit(1)
 			}
 		}()
 		if cfg.port < 0 {
@@ -167,7 +181,7 @@ func main() {
 		}
 	}
 	if cfg.port < 0 {
-		log.Printf("closing because neither --port nor --plain-port are positive")
+		slog.Info("closing because neither --port nor --plain-port are positive")
 		return
 	}
 
@@ -177,14 +191,14 @@ func main() {
 	for _, cidr := range splitList(cfg.networkList) {
 		_, ipNet, err := net.ParseCIDR(cidr)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "invalid network %q: %v\n", cidr, err)
+			slog.Error("invalid network", "cidr", cidr, "err", err)
 			os.Exit(1)
 		}
 		networks = append(networks, *ipNet)
 	}
 
 	if len(ipDomains) > 0 && len(networks) == 0 {
-		fmt.Fprintf(os.Stderr, "error: --ip-domains requires --networks to define valid target CIDRs\n")
+		slog.Error("--ip-domains requires --networks to define valid target CIDRs")
 		os.Exit(1)
 	}
 
@@ -193,11 +207,13 @@ func main() {
 
 	tabVault, err := tabvault.OpenOrCreate(cfg.vaultPath)
 	if err != nil {
-		log.Fatalf("Vault Error: %q\n%s\n", cfg.vaultPath, err)
+		slog.Error("vault open failed", "path", cfg.vaultPath, "err", err)
+		os.Exit(1)
 	}
 	conf, err := ReadConfig(cfg.confPath, tabVault, ipDomains, networks)
 	if err != nil {
-		log.Fatalf("Config Error: %q\n%s\n", cfg.confPath, err)
+		slog.Error("config load failed", "path", cfg.confPath, "err", err)
+		os.Exit(1)
 	}
 
 	conf.SetSigChan(sigChan)
@@ -210,10 +226,10 @@ func main() {
 		allowList, err := ipgate.NewDomainSet(lc.Context, cfg.ipWhitelistPath)
 		if err != nil {
 			if cfg.ipBlacklistRepo != "none" {
-				log.Printf("WARN: ip-whitelist: %v — blacklist disabled (no anti-lockout whitelist)", err)
+				slog.Warn("ip-whitelist load failed, blacklist disabled", "err", err)
 				cfg.ipBlacklistRepo = "none"
 			} else {
-				log.Printf("WARN: ip-whitelist: %v (skipping)", err)
+				slog.Warn("ip-whitelist load failed", "err", err)
 			}
 		} else if allowList != nil {
 			lc.AllowList = allowList
@@ -225,7 +241,7 @@ func main() {
 			"tables/inbound/networks.txt",
 		})
 		if err != nil {
-			log.Printf("WARN: ip-blacklist: %v (skipping)", err)
+			slog.Warn("ip-blacklist load failed", "err", err)
 		} else {
 			lc.Blocklist = blocklist
 		}
@@ -240,17 +256,17 @@ func main() {
 			sig := <-sigChan
 			switch sig {
 			case syscall.SIGUSR1:
-				log.Println("Received SIGUSR1, reloading config")
+				slog.Info("reloading config", "signal", "SIGUSR1")
 
 				// TODO kill connections to management
 				tabVault, err := tabvault.OpenOrCreate(cfg.vaultPath)
 				if err != nil {
-					log.Printf("WARN: reload: vault %q: %v (keeping current config)", cfg.vaultPath, err)
+					slog.Warn("reload failed, keeping current config", "component", "vault", "path", cfg.vaultPath, "err", err)
 					continue
 				}
 				conf, err := ReadConfig(cfg.confPath, tabVault, ipDomains, networks)
 				if err != nil {
-					log.Printf("WARN: reload: config %q: %v (keeping current config)", cfg.confPath, err)
+					slog.Warn("reload failed, keeping current config", "component", "config", "path", cfg.confPath, "err", err)
 					continue
 				}
 				conf.SetSigChan(sigChan)
@@ -265,17 +281,17 @@ func main() {
 				// Update server reference
 				lc = lc2
 			case syscall.SIGINT:
-				log.Println("Received SIGINT, shutting down (5s)")
+				slog.Info("shutting down", "signal", "SIGINT", "grace", "5s")
 				lc.Shutdown(context.Background())
 				time.Sleep(5 * time.Second)
 				os.Exit(1)
 			case syscall.SIGTERM:
-				log.Println("Received SIGTERM, shutting down (5s)")
+				slog.Info("shutting down", "signal", "SIGTERM", "grace", "5s")
 				lc.Shutdown(context.Background())
 				time.Sleep(5 * time.Second)
 				os.Exit(1)
 			default:
-				log.Printf("Received unhandled signal %s", sig)
+				slog.Warn("unhandled signal", "signal", sig)
 			}
 		}
 	}()
@@ -299,7 +315,7 @@ func envOrInt(key string, fallback int) int {
 	}
 	n, err := strconv.Atoi(v)
 	if err != nil || n <= 0 {
-		fmt.Fprintf(os.Stderr, "warn: invalid %s=%q, using default %d\n", key, v, fallback)
+		slog.Warn("invalid env value, using default", "key", key, "value", v, "default", fallback)
 		return fallback
 	}
 	return n
@@ -320,11 +336,11 @@ func Start(wg *sync.WaitGroup, lc *tlsrouter.ListenConfig, addr string, mux *htt
 	go func() {
 		defer wg.Done()
 
-		log.Printf("\nListening on %s...", addr)
+		slog.Info("listening", "addr", addr)
 		if err := lc.ListenAndProxy(addr, mux); err != nil && !errors.Is(err, net.ErrClosed) {
-			log.Printf("Server error: %v", err)
+			slog.Error("server error", "err", err)
 		}
-		log.Printf("Closed\n")
+		slog.Info("server closed")
 	}()
 	return nil
 }
@@ -337,7 +353,7 @@ func ReadConfig(filePath string, tabVault *tabvault.TabVault, ipDomains []string
 			if len(ipDomains) == 0 {
 				return tlsrouter.Config{}, fmt.Errorf("config %q not found and no --ip-domains configured — nothing to route", filePath)
 			}
-			log.Printf("WARN: config %q not found — starting with empty config (ip-domains only)", filePath)
+			slog.Warn("config not found, starting with empty config (ip-domains only)", "path", filePath)
 			conf := &tlsrouter.Config{}
 			conf.FilePath = filePath
 			conf.TabVault = tabVault
@@ -365,7 +381,7 @@ func ReadConfig(filePath string, tabVault *tabvault.TabVault, ipDomains []string
 
 		ips, err := net.LookupIP(domain)
 		if err != nil {
-			log.Printf("WARN: ip-domain %q: DNS lookup failed: %v (skipping)", domain, err)
+			slog.Warn("ip-domain DNS lookup failed", "domain", domain, "err", err)
 			continue
 		}
 		for _, ip := range ips {
@@ -381,7 +397,7 @@ func ReadConfig(filePath string, tabVault *tabvault.TabVault, ipDomains []string
 			}
 		}
 
-		fmt.Fprintf(os.Stderr, "INFO resolved ip domain IPs: %#v\n", conf.IPs)
+		slog.Info("ip-domains resolved", "ips", conf.IPs)
 	}
 
 	customAlpns := []string{"ssh"}

--- a/configfile.go
+++ b/configfile.go
@@ -6,7 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"os"
+	"log/slog"
 	"slices"
 	"strconv"
 	"strings"
@@ -20,12 +20,12 @@ func NormalizeConfig(conf *Config) (map[string][]string, map[SNIALPN]*dnsCacheEn
 	for i, app := range conf.Apps {
 		for i, srv := range app.Services {
 			if len(srv.Backends) == 0 {
-				fmt.Println("debug: warn: service has no backends")
+				slog.Warn("service has no backends")
 				continue
 			}
 
 			if len(srv.Domains) == 0 {
-				fmt.Println("debug: warn: service has no domains")
+				slog.Warn("service has no domains")
 				continue
 			}
 
@@ -92,7 +92,7 @@ func NormalizeConfig(conf *Config) (map[string][]string, map[SNIALPN]*dnsCacheEn
 			var err error
 			dnsConf.APIToken, err = conf.TabVault.ToVaultURI(dnsConf.APIToken)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "warn: DNS provider token could not be written to vault: %v\n", err)
+				slog.Warn("DNS provider token could not be written to vault", "err", err)
 				continue
 			}
 
@@ -107,7 +107,7 @@ func NormalizeConfig(conf *Config) (map[string][]string, map[SNIALPN]*dnsCacheEn
 
 func LintConfig(conf *Config, allowedAlpns []string) error {
 	if len(conf.AdminDNS.Domains) == 0 {
-		fmt.Fprintf(os.Stderr, "warn: no '_admin' domain configured — admin API disabled\n")
+		slog.Warn("no admin domain configured, admin API disabled")
 	}
 
 	for _, domain := range conf.AdminDNS.Domains {
@@ -172,7 +172,7 @@ func LintConfig(conf *Config, allowedAlpns []string) error {
 			}
 
 			if len(srv.Backends) == 0 {
-				fmt.Fprintf(os.Stderr, "warn: domains+alpns set %q have no 'backends' defined\n", snialpns)
+				slog.Warn("domains+alpns set has no backends defined", "set", snialpns)
 			}
 
 			for i, b := range srv.Backends {

--- a/dnsresolver/resolver.go
+++ b/dnsresolver/resolver.go
@@ -5,8 +5,8 @@ import (
 	"cmp"
 	"context"
 	"fmt"
+	"log/slog"
 	"net"
-	"os"
 	"time"
 
 	"github.com/miekg/dns"
@@ -37,9 +37,9 @@ func New() *Resolver {
 	}
 	if len(r.Servers) == 0 {
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "WARN: could not read /etc/resolv.conf: %v, using fallback resolvers\n", err)
+			slog.Warn("dnsresolver: could not read /etc/resolv.conf, using fallback resolvers", "err", err)
 		} else {
-			fmt.Fprintf(os.Stderr, "WARN: /etc/resolv.conf has no nameservers, using fallback resolvers\n")
+			slog.Warn("dnsresolver: /etc/resolv.conf has no nameservers, using fallback resolvers")
 		}
 		r.Servers = FallbackServers
 	}

--- a/dynamic-config.go
+++ b/dynamic-config.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"os"
 	"slices"
 	"strconv"
 	"strings"
@@ -101,6 +100,9 @@ type dnsRoute struct {
 }
 
 func dbg(tmpl string, args ...any) {
+	if !Verbose {
+		return
+	}
 	debugMux.Lock()
 	fmt.Printf(tmpl+"\n", args...)
 	debugMux.Unlock()
@@ -217,7 +219,7 @@ func getAllowedIP(
 	alpns []string,
 ) (*dnsRoute, error) {
 	if len(conf.Networks) == 0 {
-		fmt.Fprintf(os.Stderr, "DEBUG: %s: global config has no dynamic direct ip networks\n", domain)
+		dbg("DEBUG: %s: global config has no dynamic direct ip networks", domain)
 		return nil, errTryNext
 	}
 

--- a/http-80-redirect.go
+++ b/http-80-redirect.go
@@ -5,7 +5,6 @@ import (
 	"html"
 	"net/http"
 	"net/url"
-	"os"
 	"slices"
 	"strings"
 	"time"
@@ -71,7 +70,7 @@ func HandleHTTPSRedirect(w http.ResponseWriter, r *http.Request) {
 	// Reconstruct the target URL: https://<host><path>?query
 	properURL, _, _, redirectBody := EscapeAndRenderURL(r)
 	logURL, _ := url.QueryUnescape(properURL)
-	fmt.Fprintf(os.Stderr, "DEBUG: %s: redirect %s\n", r.Host, logURL)
+	dbg("DEBUG: %s: redirect %s", r.Host, logURL)
 
 	// Determine if client accepts text/html
 	isBrowser := slices.ContainsFunc(

--- a/internal/conntracker/conntracker.go
+++ b/internal/conntracker/conntracker.go
@@ -2,7 +2,7 @@ package conntracker
 
 import (
 	"encoding/csv"
-	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"time"
 )
+
+func log() *slog.Logger { return slog.Default().WithGroup("conntracker") }
 
 type record struct {
 	IP       string
@@ -109,12 +111,12 @@ func (ct *Tracker) flush() {
 	_ = os.Remove(ct.path + ".bak")
 	if _, err := os.Stat(ct.path); err == nil {
 		if err := os.Rename(ct.path, ct.path+".bak"); err != nil {
-			fmt.Fprintf(os.Stderr, "WARN: conntracker: failed to backup %s: %v\n", ct.path, err)
+			log().Warn("failed to backup", "path", ct.path, "err", err)
 			return
 		}
 	}
 	if err := os.Rename(tmp, ct.path); err != nil {
-		fmt.Fprintf(os.Stderr, "WARN: conntracker: failed to rename %s: %v\n", ct.path, err)
+		log().Warn("failed to rename", "path", ct.path, "err", err)
 		return
 	}
 
@@ -136,7 +138,7 @@ func (ct *Tracker) load() {
 
 	rows, err := r.ReadAll()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "WARN: conntracker: failed to read %s: %v\n", ct.path, err)
+		log().Warn("failed to read", "path", ct.path, "err", err)
 		return
 	}
 

--- a/internal/ipgate/domains.go
+++ b/internal/ipgate/domains.go
@@ -55,8 +55,7 @@ func NewDomainSet(ctx context.Context, csvPath string) (*DomainSet, error) {
 
 	ds.rebuildCohort()
 
-	fmt.Fprintf(os.Stderr, "INFO: ipgate: domain set %s static + %s domains from %s (resolving in background)\n",
-		commaify(len(staticPrefixes)), commaify(len(domains)), csvPath)
+	log().Info("domain set loaded", "static", commaify(len(staticPrefixes)), "domains", commaify(len(domains)), "path", csvPath)
 
 	go ds.refreshLoop(ctx)
 
@@ -100,11 +99,9 @@ func (ds *DomainSet) resolveDomains(ctx context.Context) {
 		if err != nil || len(ips) == 0 {
 			if old, ok := prev[entry.Raw]; ok {
 				next[entry.Raw] = old
-				fmt.Fprintf(os.Stderr, "WARN: ipgate: %s: resolve failed, keeping %d prior IPs: %v\n",
-					entry.Raw, len(old), err)
+				log().Warn("resolve failed, keeping prior IPs", "domain", entry.Raw, "count", len(old), "err", err)
 			} else {
-				fmt.Fprintf(os.Stderr, "WARN: ipgate: %s: resolve failed (no prior data): %v\n",
-					entry.Raw, err)
+				log().Warn("resolve failed, no prior data", "domain", entry.Raw, "err", err)
 			}
 			continue
 		}
@@ -132,7 +129,7 @@ func (ds *DomainSet) rebuildCohort() {
 
 	cohort, err := ipcohort.Parse(all)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "WARN: ipgate: domain set rebuild: %v\n", err)
+		log().Warn("domain set rebuild failed", "err", err)
 	}
 	if cohort != nil {
 		ds.cohort.Store(cohort)

--- a/internal/ipgate/format.go
+++ b/internal/ipgate/format.go
@@ -1,8 +1,12 @@
 package ipgate
 
-import "strings"
+import (
+	"log/slog"
+	"strconv"
+	"strings"
+)
 
-import "strconv"
+func log() *slog.Logger { return slog.Default().WithGroup("ipgate") }
 
 func commaify(n int) string {
 	s := strconv.Itoa(n)

--- a/internal/ipgate/ipprefix.go
+++ b/internal/ipgate/ipprefix.go
@@ -67,13 +67,13 @@ func (ps *PrefixSet) reload(ctx context.Context) error {
 
 	ps.cohort.Store(cohort)
 
-	fmt.Fprintf(os.Stderr, "INFO: ipgate: prefix set loaded %s entries\n", commaify(cohort.Size()))
+	log().Info("prefix set loaded", "entries", commaify(cohort.Size()))
 	return nil
 }
 
 func (ps *PrefixSet) refreshLoop(ctx context.Context) {
 	if err := ps.reload(ctx); err != nil {
-		fmt.Fprintf(os.Stderr, "WARN: ipgate: prefix set initial load (will retry): %v\n", err)
+		log().Warn("prefix set initial load (will retry)", "err", err)
 	}
 
 	ticker := time.NewTicker(prefixSetRefreshInterval)
@@ -85,7 +85,7 @@ func (ps *PrefixSet) refreshLoop(ctx context.Context) {
 			return
 		case <-ticker.C:
 			if err := ps.reload(ctx); err != nil {
-				fmt.Fprintf(os.Stderr, "WARN: ipgate: prefix set reload: %v\n", err)
+				log().Warn("prefix set reload failed", "err", err)
 			}
 		}
 	}

--- a/skills/tlsrouter-deploy-test/SKILL.md
+++ b/skills/tlsrouter-deploy-test/SKILL.md
@@ -94,7 +94,19 @@ VERIFY: script prints all `OK` — reachable gets 200, unreachable logs show
 `backend unreachable ... skipping ACME`, outside-network logs show
 `target IP not in any allowed network`
 
-## 6. Test connection tracker
+## 6. Test passthrough (no TLS termination)
+
+```sh
+./skills/tlsrouter-deploy-test/scripts/test-passthrough.sh PASSTHROUGH_DOMAIN [RESOLVE_HOST]
+```
+
+Where:
+- PASSTHROUGH_DOMAIN: a domain configured with `terminate_tls=false` (e.g. pbs1.m.bnna.net)
+- RESOLVE_HOST: optional, force DNS resolution to this host (e.g. tls2.slc1.bnna.net)
+
+VERIFY: script prints `OK` for both plain and explicit ALPN connections (200 response, no TLS alert error)
+
+## 7. Test connection tracker
 
 ```sh
 ./skills/tlsrouter-deploy-test/scripts/test-conntracker.sh TARGET_HOST TARGET_DOMAIN

--- a/skills/tlsrouter-deploy-test/scripts/test-passthrough.sh
+++ b/skills/tlsrouter-deploy-test/scripts/test-passthrough.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+set -e
+
+# Test passthrough (non-TLS-terminating) connections through tlsrouter.
+# Usage: ./scripts/test-passthrough.sh <domain> [resolve-host]
+#
+# Example:
+#   ./scripts/test-passthrough.sh pbs1.m.bnna.net tls2.slc1.bnna.net
+
+if test -z "$1"; then
+	echo "Usage: $0 <domain> [resolve-host]" >&2
+	echo "  domain:       passthrough domain (terminate_tls=false)" >&2
+	echo "  resolve-host: optional, force resolution to this host" >&2
+	exit 1
+fi
+
+g_domain="$1"
+g_resolve_host="$2"
+g_pass=0
+g_fail=0
+
+g_resolve_flag=""
+if test -n "$g_resolve_host"; then
+	g_resolve_ip=$(dig +short "$g_resolve_host" A | head -1)
+	if test -z "$g_resolve_ip"; then
+		echo "FAIL: could not resolve $g_resolve_host" >&2
+		exit 1
+	fi
+	g_resolve_flag="--resolve ${g_domain}:443:${g_resolve_ip}"
+fi
+
+check() {
+	b_label="$1"
+	b_extra_flags="$2"
+	# shellcheck disable=SC2086
+	b_code=$(curl -sS --max-time 5 -k $g_resolve_flag $b_extra_flags -o /dev/null -w "%{http_code}" "https://${g_domain}/" 2> /dev/null || echo "000")
+
+	if test "$b_code" = "200"; then
+		echo "OK  $b_label: $b_code"
+		g_pass=$((g_pass + 1))
+	else
+		echo "FAIL  $b_label: got $b_code, expected 200"
+		g_fail=$((g_fail + 1))
+	fi
+}
+
+echo "# Passthrough tests for $g_domain"
+if test -n "$g_resolve_host"; then
+	echo "# (resolving via $g_resolve_host → $g_resolve_ip)"
+fi
+echo ""
+
+check "passthrough (h2 + http/1.1 ALPN)" "--http2"
+check "passthrough (http/1.1 only ALPN)" "--http1.1"
+check "passthrough (no ALPN)" "--no-alpn --http1.1"
+
+echo ""
+echo "Results: $g_pass passed, $g_fail failed"
+
+if test "$g_fail" -gt 0; then
+	exit 1
+fi

--- a/tlsrouter.go
+++ b/tlsrouter.go
@@ -13,7 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -45,6 +45,8 @@ import (
 )
 
 var ErrDoNotTerminate = fmt.Errorf("a self-terminating match was found")
+
+var Verbose bool
 
 var debugMux sync.Mutex
 
@@ -382,22 +384,20 @@ func NewListenConfig(conf Config) *ListenConfig {
 
 	// setup admin acme
 	if len(conf.AdminDNS.Domains) == 0 {
-		fmt.Fprintf(os.Stderr, "[warn] no (internal) admin domains\n")
+		slog.Warn("no admin domains configured")
 	}
 	if len(conf.AdminDNS.API) == 0 ||
 		len(conf.AdminDNS.APIToken) == 0 ||
 		conf.AdminDNS.Disabled {
-		fmt.Fprintf(os.Stderr, "[warn] no ACME config for (internal) admin domains %s\n",
-			strings.Join(conf.AdminDNS.Domains, ", "),
-		)
+		slog.Warn("no ACME config for admin domains", "domains", strings.Join(conf.AdminDNS.Domains, ", "))
 	} else {
 		newDNSTokenURI, err := conf.TabVault.ToVaultURI(conf.AdminDNS.APIToken)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "warn: admin DNS API token could not be written to vault: %v\n", err)
+			slog.Warn("admin DNS API token could not be written to vault", "err", err)
 		} else if newDNSTokenURI != conf.AdminDNS.APIToken {
 			conf.AdminDNS.APIToken = newDNSTokenURI
 			if err := conf.Save(); err != nil {
-				fmt.Fprintf(os.Stderr, "warn: could not save config after vault update: %v\n", err)
+				slog.Warn("could not save config after vault update", "err", err)
 			}
 		}
 
@@ -411,11 +411,11 @@ func NewListenConfig(conf Config) *ListenConfig {
 		len(conf.AdminDNS.AdminToken) > 0 {
 		newAdminTokenURI, err := conf.TabVault.ToVaultURI(conf.AdminDNS.AdminToken)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "warn: admin internal API token could not be written to vault: %v\n", err)
+			slog.Warn("admin internal API token could not be written to vault", "err", err)
 		} else if newAdminTokenURI != conf.AdminDNS.AdminToken {
 			conf.AdminDNS.AdminToken = newAdminTokenURI
 			if err := conf.Save(); err != nil {
-				fmt.Fprintf(os.Stderr, "warn: could not save config after vault update: %v\n", err)
+				slog.Warn("could not save config after vault update", "err", err)
 			}
 		}
 	}
@@ -433,8 +433,7 @@ func NewListenConfig(conf Config) *ListenConfig {
 		for _, dnsConf := range app.DNSProviders {
 			kindOfThing, exists := appSlugs[dnsConf.Slug]
 			if exists {
-				fmt.Fprintf(os.Stderr, "[warn] conflicting duplicate slug %q, already used by %q\n",
-					dnsConf.Slug, kindOfThing)
+				slog.Warn("conflicting duplicate slug", "slug", dnsConf.Slug, "used_by", kindOfThing)
 			} else {
 				appSlugs[dnsConf.Slug] = "DNSConfig"
 			}
@@ -446,8 +445,7 @@ func NewListenConfig(conf Config) *ListenConfig {
 				wildDNSConf = &dnsConf
 				continue
 			}
-			fmt.Fprintf(os.Stderr, "[warn] ignoring duplicate wildcard DNS provider %q, already provided by %q\n",
-				dnsConf.Slug, wildDNSConf.Slug)
+			slog.Warn("ignoring duplicate wildcard DNS provider", "slug", dnsConf.Slug, "existing", wildDNSConf.Slug)
 		}
 
 		for _, dnsConf := range app.DNSProviders {
@@ -462,12 +460,10 @@ func NewListenConfig(conf Config) *ListenConfig {
 						if oldDNSConf == emptyDNSConf {
 							continue
 						}
-						fmt.Fprintf(os.Stderr, "[warn] ignoring domain exclude for %q which is included by %q\n",
-							xdomain, oldDNSConf.Slug)
+						slog.Warn("ignoring domain exclude, already included", "domain", xdomain, "by", oldDNSConf.Slug)
 					}
 				} else {
-					fmt.Fprintf(os.Stderr, "[warn] ignoring 'excluded_domains' for non-wildcard dns provider %q\n",
-						dnsConf.Slug)
+					slog.Warn("ignoring excluded_domains for non-wildcard dns provider", "slug", dnsConf.Slug)
 				}
 			}
 			for _, domain := range dnsConf.Domains {
@@ -477,16 +473,14 @@ func NewListenConfig(conf Config) *ListenConfig {
 					continue
 				}
 				if oldDNSConf == emptyDNSConf {
-					fmt.Fprintf(os.Stderr, "[warn] ignoring domain exclude for %q which is included by %q\n",
-						domain, dnsConf.Slug)
+					slog.Warn("ignoring domain exclude, already included", "domain", domain, "by", dnsConf.Slug)
 					dnsConfByDomain[domain] = &dnsConf
 				}
 				if oldDNSConf.API == dnsConf.API &&
 					oldDNSConf.APIToken == dnsConf.APIToken {
 					continue
 				}
-				fmt.Fprintf(os.Stderr, "[warn] duplicate dns provider for %q: %q (selected), %q (ignored)\n",
-					domain, oldDNSConf.Slug, dnsConf.Slug)
+				slog.Warn("duplicate dns provider", "domain", domain, "selected", oldDNSConf.Slug, "ignored", dnsConf.Slug)
 			}
 		}
 
@@ -516,7 +510,7 @@ func NewListenConfig(conf Config) *ListenConfig {
 				},
 			}
 		default:
-			fmt.Fprintf(os.Stderr, "warn: DNS API %q is not implemented, skipping domain %q\n", dnsConf.API, domain)
+			slog.Warn("DNS API not implemented, skipping", "api", dnsConf.API, "domain", domain)
 		}
 	}
 
@@ -529,7 +523,7 @@ func NewListenConfig(conf Config) *ListenConfig {
 		// lc.certmagicCache.RemoveManaged([]certmagic.SubjectIssuer{{Subject: domain}})
 
 		if acmeConf, hasDNSConf := lc.issuerConfMap[domain]; hasDNSConf {
-			fmt.Fprintf(os.Stderr, "   DEBUG: %s: TLS will terminate as per DNS config\n", domain)
+			dbg("DEBUG: %s: TLS will terminate as per DNS config", domain)
 			// note: would be better to have certmagic per-provider, maybe
 			magic := lc.newCertmagic(acmeConf.DNSProvider)
 			lc.certmagicConfMap[domain] = magic
@@ -537,14 +531,14 @@ func NewListenConfig(conf Config) *ListenConfig {
 			return magic.ManageSync(lc.Context, []string{domain})
 		}
 
-		fmt.Fprintf(os.Stderr, "   DEBUG: %s: TLS will terminate with TLS-ALPN\n", domain)
+		dbg("DEBUG: %s: TLS will terminate with TLS-ALPN", domain)
 		lc.certmagicConfMap[domain] = lc.certmagicTLSALPNOnly
 		return lc.certmagicTLSALPNOnly.ManageSync(lc.Context, []string{domain})
 	}
 
 	for _, domain := range conf.AdminDNS.Domains {
 		if err := registerACMEDomain(domain); err != nil {
-			fmt.Fprintf(os.Stderr, "could not add %q to the allowlist: %s\n", domain, err)
+			slog.Warn("could not add domain to allowlist", "domain", domain, "err", err)
 			continue
 		}
 	}
@@ -561,7 +555,7 @@ func NewListenConfig(conf Config) *ListenConfig {
 
 			domain := snialpn.SNI()
 			if err := registerACMEDomain(domain); err != nil {
-				fmt.Fprintf(os.Stderr, "SANITY FAIL: %s: could not register for ACME: %#v\n", domain, err)
+				slog.Error("could not register for ACME", "domain", domain, "err", err)
 				continue
 			}
 
@@ -571,7 +565,7 @@ func NewListenConfig(conf Config) *ListenConfig {
 			}
 
 			alpn := snialpn.ALPN()
-			fmt.Fprintf(os.Stderr, "DEBUG: %s: incoming snialpn %s\n", domain, alpn)
+			dbg("DEBUG: %s: incoming snialpn %s", domain, alpn)
 			if alpn == "h2" || alpn == "h3" || alpn == "http/1.1" || backend.ForceHTTP {
 				lc.setupHTTPReverseProxy(domain, &backend, conf.TabVault)
 				entry.service.Backends[beIndex] = backend
@@ -594,7 +588,7 @@ func (lc *ListenConfig) setupHTTPReverseProxy(domain string, backend *Backend, v
 	if backend.AuthToken != "" {
 		if vault == nil || vault.Get(backend.AuthToken) == "" {
 			authMissing = true
-			log.Printf("FATAL: auth token %q not found in vault for %s — blocking all traffic", backend.AuthToken, backend.Host)
+			slog.Error("auth token not found in vault, blocking traffic to this backend", "token", backend.AuthToken, "backend", backend.Host)
 		}
 	}
 
@@ -633,7 +627,7 @@ func (lc *ListenConfig) setupHTTPReverseProxy(domain string, backend *Backend, v
 			r.Out.Header["X-Forwarded-Proto"] = []string{"https"} // TLS terminated here
 		},
 		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
-			log.Printf("reverse proxy error for %s: %v", r.Host, err)
+			slog.Warn("reverse proxy error", "host", r.Host, "err", err)
 			w.WriteHeader(http.StatusBadGateway)
 		},
 	}
@@ -950,7 +944,7 @@ func (lc *ListenConfig) ListenAndProxy(addr string, mux *http.ServeMux) error {
 				if errors.Is(err, net.ErrClosed) {
 					break
 				}
-				fmt.Fprintf(os.Stderr, "DEBUG: (new): couldn't accept client: %#v\n", err)
+				dbg("DEBUG: (new): couldn't accept client: %#v", err)
 				continue
 			}
 
@@ -961,16 +955,15 @@ func (lc *ListenConfig) ListenAndProxy(addr string, mux *http.ServeMux) error {
 	for {
 		select {
 		case conn := <-ch:
-			peer, parseErr := netip.ParseAddrPort(conn.RemoteAddr().String())
-			if parseErr == nil {
+			if peer, parseErr := netip.ParseAddrPort(conn.RemoteAddr().String()); parseErr == nil {
 				peerAddr := peer.Addr()
 				if lc.Blocklist.Contains(peerAddr) && !lc.AllowList.Contains(peerAddr) {
-					fmt.Fprintf(os.Stderr, "INFO: rejected %s (blacklisted)\n", peerAddr)
+					slog.Info("rejected", "src", peerAddr, "reason", "blocked")
 					_ = conn.Close()
 					continue
 				}
 			}
-			fmt.Fprintf(os.Stderr, "\nDEBUG: (new): accepted %s\n", conn.RemoteAddr())
+			dbg("DEBUG: (new): accepted %s", conn.RemoteAddr())
 			go func() {
 				_, _, err = lc.proxy(conn)
 				if err != nil {
@@ -982,7 +975,7 @@ func (lc *ListenConfig) ListenAndProxy(addr string, mux *http.ServeMux) error {
 			lc.done <- context.Background()
 		case <-lc.done:
 			// TODO put an id or total uptime some such
-			fmt.Fprintf(os.Stderr, "\n\nINFO: server shutting down...\n\n")
+			slog.Info("server shutting down")
 			// TODO hard close Conn
 			_ = lc.netLn.Close()
 			_ = lc.adminServer.Close()
@@ -994,8 +987,7 @@ func (lc *ListenConfig) ListenAndProxy(addr string, mux *http.ServeMux) error {
 func (lc *ListenConfig) proxy(conn net.Conn) (r int64, w int64, retErr error) {
 	defer func() {
 		if r := recover(); r != nil {
-			log.Printf("\nRUNTIME:  %#v", r)
-			log.Println(string(debug.Stack()))
+			slog.Error("runtime panic", "panic", r, "stack", string(debug.Stack()))
 		}
 	}()
 
@@ -1013,18 +1005,20 @@ func (lc *ListenConfig) proxy(conn net.Conn) (r int64, w int64, retErr error) {
 		GetConfigForClient: func(hello *tls.ClientHelloInfo) (*tls.Config, error) {
 			conf := lc.LoadConfig()
 
-			fmt.Fprintf(os.Stderr, "DEBUG: (new): ServerName (SNI): %q\n", hello.ServerName)
-			fmt.Fprintf(os.Stderr, "DEBUG: (new): SupportedProtos (ALPN): %q\n", strings.Join(hello.SupportedProtos, ", "))
+			dbg("DEBUG: (new): ServerName (SNI): %q", hello.ServerName)
+			dbg("DEBUG: (new): SupportedProtos (ALPN): %q", strings.Join(hello.SupportedProtos, ", "))
 
 			domain := strings.ToLower(hello.ServerName)
 			alpns := hello.SupportedProtos
 			if len(alpns) == 0 {
-				fmt.Fprintf(os.Stderr, "DEBUG: (new): assuming http/1.1\n")
+				dbg("DEBUG: (new): assuming http/1.1")
 				alpns = append(alpns, "http/1.1")
 			}
 
+			slog.Info("connect", "src", hello.Conn.RemoteAddr(), "domain", domain, "alpn", strings.Join(alpns, ","))
+
 			if alpns[0] == acmez.ACMETLS1Protocol {
-				fmt.Fprintf(os.Stderr, "DEBUG: %s: handling acme ALPN challenge\n", domain)
+				dbg("DEBUG: %s: handling acme ALPN challenge", domain)
 				// note: certmagicConfMap only holds backends that terminate
 				magic := lc.certmagicConfMap[domain]
 				if magic == nil {
@@ -1051,7 +1045,7 @@ func (lc *ListenConfig) proxy(conn net.Conn) (r int64, w int64, retErr error) {
 				}
 
 				// TODO how can we check if this instance of magic cert should handle this or not?
-				fmt.Fprintf(os.Stderr, "DEBUG: %s>%s: ACME TLS-ALPN falls through (no termination found)\n", domain, alpns[0])
+				dbg("DEBUG: %s>%s: ACME TLS-ALPN falls through (no termination found)", domain, alpns[0])
 			}
 
 			var mcfg *ConfigService
@@ -1070,11 +1064,11 @@ func (lc *ListenConfig) proxy(conn net.Conn) (r int64, w int64, retErr error) {
 				var err error
 				snialpn, mcfg, err = lc.matchService(&conf, domain, alpns)
 				if err == nil {
-					fmt.Fprintf(os.Stderr, "DEBUG: %s: match: %s, %d backends\n", snialpn, strings.Join(mcfg.Domains, ", "), len(mcfg.Backends))
+					dbg("DEBUG: %s: match: %s, %d backends", snialpn, strings.Join(mcfg.Domains, ", "), len(mcfg.Backends))
 				}
 				if err != nil {
 					snialpn = NewSNIALPN(domain, alpns[0])
-					fmt.Fprintf(os.Stderr, "DEBUG: %s>%s: match err: %#v\n", domain, alpns[0], err)
+					dbg("DEBUG: %s>%s: match err: %#v", domain, alpns[0], err)
 					if !slices.Contains(conf.AdminDNS.Domains, domain) {
 						trackMismatch()
 						return nil, err
@@ -1101,7 +1095,7 @@ func (lc *ListenConfig) proxy(conn net.Conn) (r int64, w int64, retErr error) {
 					if lc.certmagicConfMap[domain] == nil {
 						return nil, fmt.Errorf("SANITY FAIL: %s: missing ACME config", snialpn)
 					}
-					fmt.Fprintf(os.Stderr, "DEBUG: %s: returning tls.Config with admin certmagic m.GetCertificate\n", snialpn)
+					dbg("DEBUG: %s: returning tls.Config with admin certmagic m.GetCertificate", snialpn)
 					return &tls.Config{
 						GetCertificate: lc.certmagicConfMap[domain].GetCertificate,
 						NextProtos:     []string{clientALPN},
@@ -1110,7 +1104,7 @@ func (lc *ListenConfig) proxy(conn net.Conn) (r int64, w int64, retErr error) {
 			}
 
 			for i, b := range mcfg.Backends {
-				fmt.Printf("DEBUG: %s: mcfg.Backends[%d]: ALPNs: %s, Host: %s, Address: %s, Port %d, Terminate %t, PROXY %d\n",
+				dbg("DEBUG: %s: mcfg.Backends[%d]: ALPNs: %s, Host: %s, Address: %s, Port %d, Terminate %t, PROXY %d",
 					snialpn, i,
 					strings.Join(b.ALPNs, ", "), b.Host, b.Address, b.Port, b.TerminateTLS, b.PROXYProto)
 			}
@@ -1132,14 +1126,14 @@ func (lc *ListenConfig) proxy(conn net.Conn) (r int64, w int64, retErr error) {
 				var err error
 				beConn, err = getBackendConn(lc.Context, b.Host)
 				if err != nil {
-					fmt.Fprintf(os.Stderr, "DEBUG: %s: could not connect to backend %q\n", snialpn, b.Host)
+					dbg("DEBUG: %s: could not connect to backend %q", snialpn, b.Host)
 					continue
 				}
 				break
 			}
 
 			if !backend.TerminateTLS {
-				fmt.Fprintf(os.Stderr, "DEBUG: %s: GetConfigForClient: ErrDoNotTerminate\n", snialpn)
+				dbg("DEBUG: %s: GetConfigForClient: ErrDoNotTerminate", snialpn)
 				return nil, ErrDoNotTerminate
 			}
 
@@ -1154,7 +1148,7 @@ func (lc *ListenConfig) proxy(conn net.Conn) (r int64, w int64, retErr error) {
 					return nil, fmt.Errorf("SANITY FAIL: %s: found backend but missing ACME config", snialpn)
 				}
 			}
-			fmt.Fprintf(os.Stderr, "DEBUG: %s: GetConfigForClient: return tls.Config with cached certmagic m.GetCertificate\n", snialpn)
+			dbg("DEBUG: %s: GetConfigForClient: return tls.Config with cached certmagic m.GetCertificate", snialpn)
 			_ = wconn.Passthru()
 
 			return &tls.Config{
@@ -1171,31 +1165,31 @@ func (lc *ListenConfig) proxy(conn net.Conn) (r int64, w int64, retErr error) {
 			var errNoTLSConf ErrorNoTLSConfig
 			if errors.As(err, &errNoTLSConf) {
 				// TODO error log channel
-				fmt.Fprintf(os.Stderr, "DEBUG: %s: no tls config: %s\n", snialpn, err)
+				dbg("DEBUG: %s: no tls config: %s", snialpn, err)
 				return int64(wconn.BytesRead.Load()), int64(wconn.BytesWritten.Load()), err
 			}
 
 			// TODO error log channel
-			fmt.Fprintf(os.Stderr, "DEBUG: %s: unknown tls handshake failure: %v: %#v\n", snialpn, conn.RemoteAddr(), err)
+			dbg("DEBUG: %s: unknown tls handshake failure: %v: %#v", snialpn, conn.RemoteAddr(), err)
 			return int64(wconn.BytesRead.Load()), int64(wconn.BytesWritten.Load()), err
 		}
 
 		terminate = false
 	} else if backend == nil {
 		if snialpn.SNI() == acmez.ACMETLS1Protocol {
-			fmt.Fprintf(os.Stderr, "DEBUG: %s: %#v ended TLS session without backend (possibly solving ACME TLS-ALPN)\n", snialpn, conn.RemoteAddr())
+			dbg("DEBUG: %s: %#v ended TLS session without backend (possibly solving ACME TLS-ALPN)", snialpn, conn.RemoteAddr())
 			return
 		}
 	}
 	if backend == nil {
 		// TODO this is panic-worthy (leaving in for testing)
-		fmt.Fprintf(os.Stderr, "SANITY FAIL: %s: backend became nil\n", snialpn)
+		slog.Error("backend became nil", "snialpn", snialpn)
 		return
 	}
 
-	fmt.Fprintf(os.Stderr, "DEBUG: %s: handle with selected backend %s\n", snialpn, backend.Host)
+	dbg("DEBUG: %s: handle with selected backend %s", snialpn, backend.Host)
 	if backend.PROXYProto == 1 || backend.PROXYProto == 2 {
-		fmt.Fprintf(os.Stderr, "DEBUG: %s: PROXY PROTO...\n", snialpn)
+		dbg("DEBUG: %s: PROXY PROTO...", snialpn)
 		header := &proxyproto.Header{
 			Version:           byte(backend.PROXYProto),
 			Command:           proxyproto.PROXY,
@@ -1210,24 +1204,24 @@ func (lc *ListenConfig) proxy(conn net.Conn) (r int64, w int64, retErr error) {
 
 	wconn.SNIALPN = snialpn
 	if terminate {
-		fmt.Fprintf(os.Stderr, "DEBUG: %s: wconn.PlainConn = NewPlainConn(tlsConn)\n", snialpn)
+		dbg("DEBUG: %s: wconn.PlainConn = NewPlainConn(tlsConn)", snialpn)
 		wconn.PlainConn = NewPlainConn(tlsConn)
 	}
 
-	fmt.Fprintf(os.Stderr, "DEBUG: %s: connection stored as %s\n", snialpn, wconn.ConnID())
+	dbg("DEBUG: %s: connection stored as %s", snialpn, wconn.ConnID())
 	lc.Conns.Store(wconn.ConnID(), wconn)
 
 	if !terminate {
 		if beConn != nil {
-			fmt.Fprintf(os.Stderr, "DEBUG: %s: HAND-OFF (Non-Terminating, TCP Tunnel)\n", snialpn)
+			dbg("DEBUG: %s: HAND-OFF (Non-Terminating, TCP Tunnel)", snialpn)
 			return wconn.tunnelTCPConn(beConn)
 		}
-		fmt.Fprintf(os.Stderr, "DEBUG: %s: HANDLED (Non-Terminating, Bad Gateway)\n", snialpn)
+		dbg("DEBUG: %s: HANDLED (Non-Terminating, Bad Gateway)", snialpn)
 		return int64(wconn.BytesRead.Load()), int64(wconn.BytesWritten.Load()), fmt.Errorf("bad gateway: no active backend available")
 	}
 
 	if backend.HTTPTunnel != nil {
-		fmt.Fprintf(os.Stderr, "DEBUG: %s: HANDLING > backend.HTTPTunnel.Inject\n", snialpn)
+		dbg("DEBUG: %s: HANDLING > backend.HTTPTunnel.Inject", snialpn)
 		// doesn't block
 		// Inject the PlainConn wrapper (not *tls.Conn). It exposes only
 		// net.Conn so http.Server's rwc.(*tls.Conn) assertion fails and h2c
@@ -1236,7 +1230,7 @@ func (lc *ListenConfig) proxy(conn net.Conn) (r int64, w int64, retErr error) {
 		retErr = backend.HTTPTunnel.Inject(wconn.PlainConn)
 		wconn.wg.Wait()
 	} else if beConn != nil {
-		fmt.Fprintf(os.Stderr, "DEBUG: %s: HANDLING > TunnelTCPConn(cConn, beConn)\n", snialpn)
+		dbg("DEBUG: %s: HANDLING > TunnelTCPConn(cConn, beConn)", snialpn)
 		_, _, retErr = TunnelTCPConn(snialpn, wconn.PlainConn, beConn)
 		_ = conn.Close()
 	} else {
@@ -1248,9 +1242,9 @@ func (lc *ListenConfig) proxy(conn net.Conn) (r int64, w int64, retErr error) {
 		text := fmt.Sprintf("HTTP/1.1 502 Bad Gateway\r\nContent-Type: text/plain\r\nContent-Length: %d\r\n\r\n%s", n, msg)
 		_, _ = wconn.PlainConn.Write([]byte(text))
 		_ = conn.Close()
-		fmt.Fprintf(os.Stderr, "DEBUG: %s: HANDLED > Bad Gateway (Terminated)\n", snialpn)
+		dbg("DEBUG: %s: HANDLED > Bad Gateway (Terminated)", snialpn)
 	}
-	fmt.Fprintf(os.Stderr, "DEBUG: %s: CLOSED\n", snialpn)
+	dbg("DEBUG: %s: CLOSED", snialpn)
 	if backend != nil {
 		lc.connTracker.Track(snialpn.SNI(), backend.Address, wconn.BytesRead.Load(), wconn.BytesWritten.Load())
 	}
@@ -1283,7 +1277,7 @@ func TunnelTCPConn(snialpn SNIALPN, cConn net.Conn, beConn net.Conn) (r int64, w
 		r, err = io.Copy(beConn, cConn)
 		if err != nil {
 			rErr = err
-			fmt.Fprintf(os.Stderr, "DEBUG: %s: Plain Tunnel: error copying client>backend: %v\n", snialpn, err)
+			dbg("DEBUG: %s: Plain Tunnel: error copying client>backend: %v", snialpn, err)
 		}
 
 		if c, ok := beConn.(*net.TCPConn); ok {
@@ -1298,7 +1292,7 @@ func TunnelTCPConn(snialpn SNIALPN, cConn net.Conn, beConn net.Conn) (r int64, w
 		w, err = io.Copy(cConn, beConn)
 		if err != nil {
 			wErr = err
-			fmt.Fprintf(os.Stderr, "DEBUG: %s: Plain Tunnel: error copying backend>client: %v\n", snialpn, err)
+			dbg("DEBUG: %s: Plain Tunnel: error copying backend>client: %v", snialpn, err)
 		}
 
 		if c, ok := cConn.(*net.TCPConn); ok {
@@ -1342,7 +1336,7 @@ func (wconn *wrappedConn) tunnelTCPConn(beConn net.Conn) (r int64, w int64, retE
 
 		_, err := io.Copy(beConn, conn)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "DEBUG: %s: Raw Tunnel: error copying client>backend: %v\n", wconn.SNIALPN, err)
+			dbg("DEBUG: %s: Raw Tunnel: error copying client>backend: %v", wconn.SNIALPN, err)
 		}
 
 		if c, ok := beConn.(*net.TCPConn); ok {
@@ -1355,7 +1349,7 @@ func (wconn *wrappedConn) tunnelTCPConn(beConn net.Conn) (r int64, w int64, retE
 
 		_, err := io.Copy(conn, beConn)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "DEBUG: %s: Raw Tunnel: error copying backend>client: %v\n", wconn.SNIALPN, err)
+			dbg("DEBUG: %s: Raw Tunnel: error copying backend>client: %v", wconn.SNIALPN, err)
 		}
 
 		if c, ok := conn.(*net.TCPConn); ok {
@@ -1523,7 +1517,7 @@ func (lc *ListenConfig) resolveOrExtend(conf *Config, domain string, alpns []str
 		}
 	}
 
-	fmt.Fprintf(os.Stderr, "WARN: DNS refresh for %s failed: %v, extending cached entry\n", domain, err)
+	slog.Warn("DNS refresh failed, extending cached entry", "domain", domain, "err", err)
 
 	snialpn := NewSNIALPN(domain, alpns[0])
 	lc.serviceMu.Lock()
@@ -1606,7 +1600,10 @@ func (wconn *wrappedConn) Write(b []byte) (int, error) {
 		return n, err
 	}
 
-	fmt.Fprintf(os.Stderr, "Handshake: %x\n", b)
+	// This error is intentional: crypto/tls calls Write to send a TLS alert
+	// when GetConfigForClient returns an error (e.g. ErrDoNotTerminate for
+	// passthrough). The error return prevents the alert from reaching the
+	// client, which would kill the connection before the tunnel is established.
 	wconn.once.Do(wconn.wg.Done)
 	return 0, fmt.Errorf("sanity fail: wrappedConn does not support Write")
 }


### PR DESCRIPTION
## Summary

- Replace all `fmt.Fprintf(os.Stderr)` and `fmt.Println` runtime logging with structured `log/slog`
- Add `--verbose` flag that gates DEBUG trace output (silent by default)
- INFO-level connection log on every accepted connection: `level=INFO msg=connect src=<ip> domain=<sni> alpn=<protos>`
- Use `slog.WithGroup` for `ipgate` and `conntracker` packages (keys prefixed as `ipgate.entries`, `conntracker.path`, etc.)
- Suppress slog timestamps (journald provides them)
- Add comment on `wrappedConn.Write` explaining why the error return is load-bearing
- Add passthrough test script for non-TLS-terminating backends

## Changes by package

| Package | Before | After |
|---------|--------|-------|
| `cmd/tlsrouter` | `log.Printf` | `slog.Warn/Info` + `--verbose` flag |
| `tlsrouter` | `fmt.Fprintf(os.Stderr, ...)` | `slog.Warn/Info` + `dbg()` for verbose |
| `dnsresolver` | `fmt.Fprintf(os.Stderr, "WARN: ...")` | `slog.Warn(...)` |
| `internal/ipgate` | `fmt.Fprintf(os.Stderr, ...)` | `log().Warn/Info(...)` via WithGroup |
| `internal/conntracker` | `fmt.Fprintf(os.Stderr, ...)` | `log().Warn(...)` via WithGroup |
| `configfile` | `fmt.Println("debug: warn: ...")` | `slog.Warn(...)` |
| `api` | `fmt.Println(...)` | `dbg(...)` (verbose-only) |

## No behavioral changes

- Blocklist rejection stays at TCP accept (before TLS Hello), same as v0.9.0
- `wrappedConn.Write` error return unchanged — only removes `fmt.Fprintf` noise, adds explanatory comment
- `"reverse proxy error"` demoted from ERROR to WARN (context cancellations are normal client disconnects)

## Example output

```
level=INFO msg=connect src=203.0.113.42:51234 domain=app.example.com alpn=h2,http/1.1
level=INFO msg=rejected src=198.51.100.7 reason=blocked
level=WARN msg="reverse proxy error" host=app.example.com err="context canceled"
level=INFO msg="prefix set loaded" ipgate.entries="3,569,426"
level=WARN msg="resolve failed, keeping prior IPs" ipgate.domain=monitor.example.com ipgate.count=2 ipgate.err="no A records for monitor.example.com"
```

With `--verbose`:
```
DEBUG: (new): ServerName (SNI): "app.example.com"
DEBUG: (new): SupportedProtos (ALPN): "h2, http/1.1"
DEBUG: app.example.com>h2: match: app.example.com, 1 backends
DEBUG: app.example.com>h2: GetConfigForClient: return tls.Config with cached certmagic
```

## Test plan

- [x] Deploy without `--verbose` — no DEBUG lines in logs
- [x] Deploy with default flags — structured INFO/WARN output confirmed
- [x] Passthrough (non-TLS-terminating) connections work with h2+http/1.1, http/1.1-only, and no-ALPN
- [x] Blocked connections rejected at accept level, logged with `reason=blocked`
- [x] WithGroup prefixes appear correctly (`ipgate.*`, `conntracker.*`)
- [x] No "Handshake: 15030100020250" log noise