### PR TITLE
fix(acme): check ALPN not SNI when identifying TLS-ALPN-01 challenge

### DIFF
--- a/tlsrouter.go
+++ b/tlsrouter.go
@@ -1176,7 +1176,7 @@ func (lc *ListenConfig) proxy(conn net.Conn) (r int64, w int64, retErr error) {
 
 		terminate = false
 	} else if backend == nil {
-		if snialpn.SNI() == acmez.ACMETLS1Protocol {
+		if snialpn.ALPN() == acmez.ACMETLS1Protocol {
 			dbg("DEBUG: %s: %#v ended TLS session without backend (possibly solving ACME TLS-ALPN)", snialpn, conn.RemoteAddr())
 			return
 		}


### PR DESCRIPTION
## Summary

- Fix `snialpn.SNI()` → `snialpn.ALPN()` in the post-handshake ACME guard
- Eliminates spurious `"backend became nil"` errors after successful ACME TLS-ALPN-01 challenges

## Problem

After certmagic successfully serves a TLS-ALPN-01 challenge certificate, the connection cleanup checks whether to silently return (no backend needed — the challenge is done). The guard compared `snialpn.SNI()` (e.g. `app.example.com`) against `"acme-tls/1"`, which never matches. Every successful challenge fell through to the `"backend became nil"` error path.

Before fix (from production logs):
```
info    served key authentication certificate    {"server_name": "node1.example.com", "challenge": "tls-alpn-01", ...}
level=ERROR msg="backend became nil" snialpn=node1.example.com>acme-tls/1
level=ERROR msg="backend became nil" snialpn=node1.example.com>acme-tls/1
info    authorization finalized    {"identifier": "node1.example.com", "authz_status": "valid"}
```

This pattern repeated for every ACME challenge, with 2-5 ERROR lines per renewal depending on how many Let's Encrypt validation probes arrived.

## Fix

Check `snialpn.ALPN()` instead, which correctly returns `"acme-tls/1"` for challenge connections.

## Test results

Deployed v0.9.1 (includes this fix) to 4 hosts:

- **Passthrough (non-terminated TLS):** 3/3 tests passed (h2+http/1.1, http/1.1-only, no-ALPN)
- **Health checks:** 2/2 passed on each systemd host (HTTPS reachable, HTTP redirect)
- **ACME ALPN fix:** Zero `"backend became nil"` errors since deployment. No ACME challenges have triggered yet post-deploy (certs freshly loaded), but the error path is eliminated at the code level — `snialpn.ALPN()` now correctly matches `"acme-tls/1"`.

Tracked in #62.