### PR TITLE
docs: update README and agent files for current implementation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,19 +21,23 @@ Uses commit date when worktree is clean, current time when dirty. Verify with:
 Deploy to a host:
 
 ```sh
-ssh vms.example.com "sudo systemctl stop tlsrouter"
-scp ./agents/tmp/tlsrouter vms.example.com:~/bin/tlsrouter
-ssh vms.example.com "sudo systemctl start tlsrouter"
+./skills/tlsrouter-deploy-test/scripts/build-and-deploy.sh app@vms.example.com
 ```
 
-- MUST: Stop the service before scp — binary is running, overwrite fails otherwise
-- Verify: `ssh vms.example.com "sudo systemctl is-active tlsrouter"` → `active`
+The script scps as `tlsrouter.new`, then `mv` + `chmod` — no need to stop the service first.
+Restart with serviceman (NEVER use sudo):
+
+```sh
+ssh app@vms.example.com "~/.local/bin/serviceman restart --name tlsrouter"
+```
 
 Install with serviceman (first time):
 
 ```sh
 serviceman add --name tlsrouter -- ~/bin/tlsrouter daemon
 ```
+
+Check `memory/reference_deploy_targets.md` for host-specific users and service managers (systemd vs OpenRC).
 
 ## Directory Layout
 
@@ -46,7 +50,11 @@ serviceman add --name tlsrouter -- ~/bin/tlsrouter daemon
 | `tlsrouter.go` | Core proxy logic, PlainConn, wrappedConn |
 | `api.go` | Admin API handlers, connection reporting |
 | `configfile.go` | CSV config parser |
-| `dynamic-config.go` | CNAME/SRV-based dynamic routing |
+| `dynamic-config.go` | CNAME/SRV-based dynamic routing, dbg() verbose output |
+| `http-80-redirect.go` | Plain HTTP → HTTPS redirect listener |
+| `dnsresolver/` | DNS resolver with TTL tracking |
+| `internal/ipgate/` | IP allowlist (domain-based) and blocklist (git-managed prefix sets) |
+| `internal/conntracker/` | Connection tracker — domain-to-IP mapping, persisted as TSV |
 
 Server paths:
 
@@ -58,17 +66,18 @@ Server paths:
 
 ## Static Config (backends.csv)
 
-Headers: `app_slug,domain,alpn,backend_address,backend_port,terminate_tls,connect_tls,skip_tls_verify,auth,allowed_client_hostnames`
+Headers: `app_slug,domain,alpn,backend_address,backend_port,terminate_tls,connect_tls,rewrite_host,skip_tls_verify,auth,allowed_client_hostnames`
 
 ```csv
-_admin,vms.example.com,admin,vault://5d7d83f3...,,,,,
-myapp,site.example.com,ssh,127.0.0.1,22,false,false,false,
-myapp,site.example.com,http/1.1,172.16.0.1,443,true,true,true,vault://a1b2c3...,
+_admin,vms.example.com,admin,vault://5d7d83f3...,,,,,,
+myapp,site.example.com,ssh,127.0.0.1,22,false,false,,false,
+myapp,site.example.com,http/1.1,172.16.0.1,443,true,true,backend.example.com,true,vault://a1b2c3...,
 ```
 
 - `_admin` app_slug with `alpn=admin` → admin API backend (still HTTP on the wire; `admin` is a config shim, not a real ALPN)
 - `terminate_tls=true` → tlsrouter terminates TLS
 - `connect_tls=true` → re-encrypts to backend
+- `rewrite_host` → overrides Host header sent to backend (fixes DNS rebinding and auth domain mismatch with connect_tls)
 - `auth` → vault entry reference, MUST fail closed if missing
 - Multiple rows per domain for different ALPNs (ssh, http/1.1)
 
@@ -101,7 +110,7 @@ SRV     _http._tcp.example.com   10 3080 tls-10-11-2-21.vms.example.com  300
 SRV      _ssh._tcp.example.com   10   22 tls-10-11-2-21.vms.example.com  300
 ```
 
-CLI flags: `--ip-domains` (which domains are IP-pattern domains), `--networks` (allowed CIDRs)
+CLI flags: `--ip-domains` (which domains are IP-pattern domains), `--networks` (allowed CIDRs, typically 10.x ranges)
 
 ## Key Architecture
 
@@ -133,9 +142,18 @@ curl --http1.1 https://app.example.com/
 # Auth-gated (expect 401)
 curl https://app.example.com/
 
-# Logs
-ssh vms.example.com "sudo journalctl -u tlsrouter --no-pager -n 20"
+# Passthrough (non-terminated TLS)
+./skills/tlsrouter-deploy-test/scripts/test-passthrough.sh passthru.example.com
+
+# Logs (uses slog structured output)
+ssh app@vms.example.com "journalctl --user -u tlsrouter --no-pager -n 20"
 ```
+
+## Logging
+
+Uses `log/slog` with `TextHandler` to stderr. Timestamps suppressed (journald provides them).
+Internal packages use `slog.WithGroup` for namespaced keys: `ipgate.*`, `conntracker.*`.
+Debug output gated behind `--verbose` flag via `dbg()` function in `dynamic-config.go`.
 
 ## Port Table (key entries)
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,8 @@ Supports both static and dynamic TLS routing.
 
 ```sh
 tlsrouter \
-   --config ~/.config/tlsrouter/backends.csv \
-   --vault ~/.config/tlsrouter/secrets.tsv \
    --ip-domains vm.example.com \
-   --networks 192.168.1.0/24 \
+   --networks 10.0.0.0/8 \
    --bind 0.0.0.0 \
    --port 443
 ```
@@ -17,13 +15,17 @@ tlsrouter \
 Configured backends are loaded statically, while URLs like <https://tls-192-168-1-100.vm.example.com> are dynamically proxied -
 provided that the ip domain and ip-as-subdomain addresses match the allowed domain and networks.
 
-- `--config` — Path to backends config CSV file (default: `~/.config/tlsrouter/backends.csv`)
-- `--vault` — Path to vault TSV file (default: `~/.config/tlsrouter/secrets.tsv`)
 - `--ip-domains` — Comma-separated base domains for dynamic IP URLs (default: `example.localdomain`)
 - `--networks` — Allowed networks for dynamic IP proxying (default: `169.254.0.0/16`)
 - `--bind` — Address to bind to (default: `0.0.0.0`)
 - `--port` — TLS port to listen on; `-1` to disable (default: `443`)
 - `--plain-port` — Plain HTTP port for redirects; `-1` to disable (default: `80`)
+- `--config` — Path to backends config CSV file (default: `~/.config/tlsrouter/backends.csv`)
+- `--vault` — Path to vault TSV file (default: `~/.config/tlsrouter/secrets.tsv`)
+- `--ip-whitelist` — Path to IP whitelist CSV (IPs/CIDRs/domains that bypass the blacklist)
+- `--ip-blacklist-repo` — Git repo URL for IP blacklist, or `none` to disable
+- `--ip-blacklist-dir` — Path to IP blacklist data directory
+- `--verbose` — Enable debug trace output
 
 ## Environment Variables
 
@@ -31,13 +33,13 @@ All flags can be set via environment variables (flags take precedence):
 
 | Flag | Env Var | Default |
 | :--- | :------ | :------ |
+| `--ip-domains` | `DYNAMIC_IP_DOMAIN` | `example.localdomain` |
+| `--networks` | `DYNAMIC_HOST_NETWORKS` | `169.254.0.0/16` |
 | `--port` | `PORT` | `443` |
 | `--plain-port` | `PLAIN_PORT` | `80` |
 | `--bind` | `BIND` | `0.0.0.0` |
 | `--config` | `CONFIG_FILE` | `~/.config/tlsrouter/backends.csv` |
 | `--vault` | `VAULT_FILE` | `~/.config/tlsrouter/secrets.tsv` |
-| `--ip-domains` | `DYNAMIC_IP_DOMAIN` | `example.localdomain` |
-| `--networks` | `DYNAMIC_HOST_NETWORKS` | `169.254.0.0/16` |
 
 A `.env` file in the working directory is loaded automatically.
 
@@ -95,7 +97,7 @@ Note: ports must be selected according to the table below. Arbitrary ports are n
 
 ## Dynamic IP URL Mapping
 
-The URL pattern is There are two URL patterns:
+There are two URL patterns:
 - `<layer4>-<ipv4-octets>-<ip-domain>`
 - tls-192-168-1-100.example.com (Handles / Terminates TLS)
 - tcp-192-168-1-100.example.com (Raw TCP Passthrough / Non-Terminating)

--- a/skills/tlsrouter-deploy-test/SKILL.md
+++ b/skills/tlsrouter-deploy-test/SKILL.md
@@ -117,6 +117,6 @@ VERIFY: script prints all `OK` — connections.tsv exists, has header, contains 
 ## Notes
 
 - Port 8443 or other non-standard ports may be firewalled. Test on the production port (443) with controlled blocklist data.
-- The blocklist loads asynchronously (~2-15s depending on data size). Wait for `INFO: ipgate: prefix set loaded N entries` in logs before testing.
+- The blocklist loads asynchronously (~2-15s depending on data size). Wait for `level=INFO msg="prefix set loaded" ipgate.entries=N` in logs before testing.
 - Git-managed blocklist directories get overwritten on fetch. Use a local `file://` repo for controlled testing.
 - NEVER: Leave test blocklist config in production. Always restore and verify.


### PR DESCRIPTION
## Summary

- Add missing CLI flags to README (`--verbose`, `--ip-whitelist`, `--ip-blacklist-repo`, `--ip-blacklist-dir`)
- Reorder flags with `--ip-domains` and `--networks` first (primary operational flags)
- Fix AGENTS.md deploy instructions: use `build-and-deploy.sh` script and serviceman (no sudo)
- Add `rewrite_host` column to backends.csv documentation and examples
- Add missing packages to directory layout (`dnsresolver/`, `internal/ipgate/`, `internal/conntracker/`, `http-80-redirect.go`)
- Add Logging section documenting slog, `WithGroup`, and `--verbose`/`dbg()`
- Add passthrough test command to Testing section
- Fix broken grammar in README Dynamic IP URL Mapping section
- Update SKILL.md log format to match slog structured output

## Test plan

- [ ] Verify `tlsrouter --help` output matches documented flags
- [ ] Verify backends.csv header order matches `configfile.go:expectedHeaders`