### PR TITLE
fix(ipgate): enable git GC to prevent unbounded .git growth

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/mholt/acmez/v3 v3.1.4
 	github.com/miekg/dns v1.1.69
 	github.com/pires/go-proxyproto v0.9.0
-	github.com/therootcompany/golib/net/gitshallow v0.9.0
+	github.com/therootcompany/golib/net/gitshallow v0.9.1
 	github.com/therootcompany/golib/net/ipcohort v0.9.0
 	golang.org/x/sync v0.20.0
 	golang.org/x/sys v0.40.0

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,8 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/therootcompany/golib/io/transform/gsheet2csv v1.0.3 h1:220hPRUieZtIc6cWlAwKbNzOJxAbscsJy83+2qIai2Q=
 github.com/therootcompany/golib/io/transform/gsheet2csv v1.0.3/go.mod h1:/GwkISS5hHJPhYIQ9B92zAfo56VuEP2NW2N10InCcWs=
-github.com/therootcompany/golib/net/gitshallow v0.9.0 h1:JNDqTD8HG4TYTmUc18Vo2MJ6tJ/12pcQo+8qG9rdV9k=
-github.com/therootcompany/golib/net/gitshallow v0.9.0/go.mod h1:S/3OK7wMOqJJjP79U9Qw/l3jjEyrb/zsjJ8HAPAX/Fc=
+github.com/therootcompany/golib/net/gitshallow v0.9.1 h1:VI/Q4jViKvVuJ+lzZrD7suhSXLfNNhUcd4ZJrkpTP/Q=
+github.com/therootcompany/golib/net/gitshallow v0.9.1/go.mod h1:S/3OK7wMOqJJjP79U9Qw/l3jjEyrb/zsjJ8HAPAX/Fc=
 github.com/therootcompany/golib/net/ipcohort v0.9.0 h1:j3AaoW2u4XQJz1ya6fixv3pb3KgxIpZV8t0082/kS3E=
 github.com/therootcompany/golib/net/ipcohort v0.9.0/go.mod h1:Ljcnt2xOryVDGIVV5Kzt5hj2LhW4lBAWo5OeeVYU9ys=
 github.com/zeebo/assert v1.1.0 h1:hU1L1vLTHsnO8x8c9KAR5GmM5QscxHg5RNU5z5qbUWY=

--- a/internal/ipgate/ipprefix.go
+++ b/internal/ipgate/ipprefix.go
@@ -31,8 +31,10 @@ func NewPrefixSet(ctx context.Context, repoURL, dataPath string, files []string)
 		return nil, fmt.Errorf("ipgate: create data dir: %w", err)
 	}
 
+	repo := gitshallow.New(repoURL, dataPath, 0, "")
+
 	ps := &PrefixSet{
-		repo:  gitshallow.New(repoURL, dataPath, 1, ""),
+		repo:  repo,
 		files: files,
 	}
 	ps.cohort.Store(&ipcohort.Cohort{})


### PR DESCRIPTION
## Summary

- Upgrade `gitshallow` to v0.9.1 (therootcompany/golib#147) which fixes unbounded `.git` growth on shallow-clone repos
- Use library defaults: depth 3 (was 1) and GCInterval 1 (now default)
- v0.9.1 uses depth-3 windowed fetch + reflog expire/prune/gc sequence that keeps `.git` at ~2MB steady state without OOM on 512MB VMs

## Root cause

`--depth 1` on every fetch added a new `.git/shallow` entry per cycle. Each entry pinned a full snapshot as reachable — 17 entries = 400MB on tls1, immune to any GC strategy. Plain `git gc` then OOM'd trying to repack all 400MB at once on 512MB VMs.

## Result (from upstream testing)

- `.git/shallow`: 1 entry (was 17+)
- `.git` size: ~2MB steady state (was 400MB+)
- GC peak RAM: ~10MB (was 400MB+)

## Test plan

- [x] `go build ./...` passes
- [ ] Deploy to tlsrouter instances and verify `.git` size stays stable over 24h
- [ ] Verify on test instance (512MB RAM) — no OOM