### PR TITLE
feat(acme): gate wildcard issuance with ask_url and DNS probe + rate limit

### DIFF
--- a/askurl.go
+++ b/askurl.go
@@ -1,0 +1,56 @@
+package tlsrouter
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// askURLClient is the HTTP client used for ask_url checks. It deliberately
+// has no redirect follower and a short timeout — the policy endpoint should
+// answer synchronously with a status code.
+var askURLClient = &http.Client{
+	Timeout: 5 * time.Second,
+	CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	},
+}
+
+// askURLAllows asks an external endpoint whether an ACME certificate may be
+// issued for name. It performs GET <askURL>?domain=<name> and treats only
+// HTTP 200 as "allow". Any other status or network error is "deny".
+func askURLAllows(ctx context.Context, askURL, name string) error {
+	if askURL == "" {
+		return fmt.Errorf("ask_url not configured for wildcard issuance of %q", name)
+	}
+
+	u, err := url.Parse(askURL)
+	if err != nil {
+		return fmt.Errorf("invalid ask_url %q: %w", askURL, err)
+	}
+	q := u.Query()
+	q.Set("domain", name)
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return fmt.Errorf("build ask request: %w", err)
+	}
+
+	resp, err := askURLClient.Do(req)
+	if err != nil {
+		slog.Warn("ask_url request failed", "domain", name, "ask_url", askURL, "err", err)
+		return fmt.Errorf("ask_url request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		slog.Info("ask_url allowed issuance", "domain", name, "ask_url", askURL)
+		return nil
+	}
+	slog.Warn("ask_url denied issuance", "domain", name, "ask_url", askURL, "status", resp.StatusCode)
+	return fmt.Errorf("ask_url denied issuance for %q (status %d)", name, resp.StatusCode)
+}

--- a/cmd/tlsrouter/main.go
+++ b/cmd/tlsrouter/main.go
@@ -77,18 +77,20 @@ func printVersion() {
 }
 
 type MainConfig struct {
-	showVersion     bool
-	verbose         bool
-	ipDomainList    string
-	networkList     string
-	port            int
-	plainPort       int
-	bind            string
-	confPath        string
-	vaultPath       string
-	ipWhitelistPath string
-	ipBlacklistDir  string
-	ipBlacklistRepo string
+	showVersion        bool
+	verbose            bool
+	ipDomainList       string
+	networkList        string
+	port               int
+	plainPort          int
+	bind               string
+	confPath           string
+	vaultPath          string
+	ipWhitelistPath    string
+	ipBlacklistDir     string
+	ipBlacklistRepo    string
+	wildcardRateLimit  int
+	wildcardRateWindow time.Duration
 }
 
 func main() {
@@ -127,6 +129,8 @@ func main() {
 	fs.StringVar(&cfg.ipWhitelistPath, "ip-whitelist", filepath.Join(defaultConfigDir(), "allowed.csv"), "Path to IP whitelist CSV file (IPs/CIDRs that bypass the blacklist)")
 	fs.StringVar(&cfg.ipBlacklistDir, "ip-blacklist-dir", defaultBlocklistPath(), "Path to IP blacklist data directory")
 	fs.StringVar(&cfg.ipBlacklistRepo, "ip-blacklist-repo", defaultBlocklistRepo, "Git repo URL for IP blacklist, or 'none' to disable")
+	fs.IntVar(&cfg.wildcardRateLimit, "wildcard-rate-limit", envOrInt("WILDCARD_RATE_LIMIT", 10), "Max ACME issuances per detected wildcard parent zone within --wildcard-rate-window. 0 disables the cap.")
+	fs.DurationVar(&cfg.wildcardRateWindow, "wildcard-rate-window", envOrDuration("WILDCARD_RATE_WINDOW", 24*time.Hour), "Sliding window for --wildcard-rate-limit (e.g. 24h, 168h)")
 
 	fs.Usage = func() {
 		printVersion()
@@ -215,6 +219,8 @@ func main() {
 		slog.Error("config load failed", "path", cfg.confPath, "err", err)
 		os.Exit(1)
 	}
+	conf.WildcardRateLimit = cfg.wildcardRateLimit
+	conf.WildcardRateWindow = cfg.wildcardRateWindow
 
 	conf.SetSigChan(sigChan)
 
@@ -269,6 +275,8 @@ func main() {
 					slog.Warn("reload failed, keeping current config", "component", "config", "path", cfg.confPath, "err", err)
 					continue
 				}
+				conf.WildcardRateLimit = cfg.wildcardRateLimit
+				conf.WildcardRateWindow = cfg.wildcardRateWindow
 				conf.SetSigChan(sigChan)
 				mux := http.NewServeMux()
 				setupRouter(conf, mux)
@@ -306,6 +314,19 @@ func defaultConfigDir() string {
 		configHome = filepath.Join(home, ".config")
 	}
 	return filepath.Join(configHome, "tlsrouter")
+}
+
+func envOrDuration(key string, fallback time.Duration) time.Duration {
+	v := os.Getenv(key)
+	if v == "" {
+		return fallback
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		slog.Warn("invalid env duration, using default", "key", key, "value", v, "default", fallback)
+		return fallback
+	}
+	return d
 }
 
 func envOrInt(key string, fallback int) int {

--- a/configfile.go
+++ b/configfile.go
@@ -183,6 +183,17 @@ func LintConfig(conf *Config, allowedAlpns []string) error {
 					return fmt.Errorf("target %d in set %q has empty 'port'", i, snialpns)
 				}
 			}
+
+			hasWildcard := false
+			for _, domain := range srv.Domains {
+				if strings.HasPrefix(domain, "*.") {
+					hasWildcard = true
+					break
+				}
+			}
+			if srv.AskURL != "" && !hasWildcard {
+				slog.Warn("ask_url is only consulted for wildcard services; ignored on non-wildcard service", "service", srv.Slug, "domains", strings.Join(srv.Domains, ","))
+			}
 		}
 	}
 
@@ -201,6 +212,7 @@ var expectedHeaders = []string{
 	"skip_tls_verify",
 	"auth",
 	"allowed_client_hostnames",
+	"ask_url",
 }
 
 func ReadCSVToConfig(r *csv.Reader) (*Config, error) {
@@ -286,6 +298,10 @@ func ReadCSVToConfig(r *csv.Reader) (*Config, error) {
 		if i, ok := headerIndices["allowed_client_hostnames"]; ok && i < len(record) && record[i] != "" {
 			allowedClientHostnames = strings.Split(record[i], ",")
 		}
+		askURL := ""
+		if i, ok := headerIndices["ask_url"]; ok && i < len(record) {
+			askURL = record[i]
+		}
 
 		// handle the special case of the admin app
 		if appSlug == "_admin" && len(domain) > 0 {
@@ -365,6 +381,7 @@ func ReadCSVToConfig(r *csv.Reader) (*Config, error) {
 				ALPNs:                  []string{alpn},
 				Backends:               []Backend{},
 				AllowedClientHostnames: allowedClientHostnames,
+				AskURL:                 askURL,
 			}
 			serviceMap[serviceSlug] = service
 			// app.Services = append(app.Services, *service)
@@ -381,6 +398,11 @@ func ReadCSVToConfig(r *csv.Reader) (*Config, error) {
 				if !slices.Contains(service.AllowedClientHostnames, hostname) && hostname != "" {
 					service.AllowedClientHostnames = append(service.AllowedClientHostnames, hostname)
 				}
+			}
+			if service.AskURL == "" && askURL != "" {
+				service.AskURL = askURL
+			} else if askURL != "" && service.AskURL != askURL {
+				slog.Warn("conflicting ask_url for service, keeping first", "service", service.Slug, "existing", service.AskURL, "ignored", askURL)
 			}
 		}
 
@@ -443,6 +465,7 @@ type CSVRecord struct {
 	SkipTLSVerify          bool
 	Auth                   string
 	AllowedClientHostnames string
+	AskURL                 string
 }
 
 // ToCSV converts the config to a CSV string, using ToRecords and RecordsToCSV.
@@ -476,6 +499,7 @@ func (c *Config) ToRecords() ([]CSVRecord, error) {
 							SkipTLSVerify:          backend.SkipTLSVerify,
 							Auth:                   backend.AuthToken,
 							AllowedClientHostnames: strings.Join(service.AllowedClientHostnames, ";"),
+							AskURL:                 service.AskURL,
 						})
 					}
 				}
@@ -548,6 +572,7 @@ func RecordsToCSV(csvw *csv.Writer, records []CSVRecord) error {
 			fmt.Sprintf("%t", record.SkipTLSVerify),
 			record.Auth,
 			record.AllowedClientHostnames,
+			record.AskURL,
 		}
 		if err := csvw.Write(csvRow); err != nil {
 			return fmt.Errorf("failed to write CSV record: %w", err)

--- a/internal/wildcardlimit/wildcardlimit.go
+++ b/internal/wildcardlimit/wildcardlimit.go
@@ -1,0 +1,248 @@
+// Package wildcardlimit tracks ACME issuance attempts against wildcard parent
+// zones detected by DNS probing. It enforces a sliding-window cap on new
+// issuances per zone and persists counters to a TSV file alongside other
+// tlsrouter metrics so the limit survives process restarts.
+package wildcardlimit
+
+import (
+	"encoding/csv"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+func log() *slog.Logger { return slog.Default().WithGroup("wildcardlimit") }
+
+type zoneBucket struct {
+	WindowTimes  []time.Time
+	LastIssuedAt time.Time
+	LastDeniedAt time.Time
+	TotalIssued  uint64
+	TotalDenied  uint64
+	ProbeHits    uint64 // probe detected this zone as wildcard
+}
+
+// Limiter enforces a per-zone sliding-window cap on ACME issuance attempts.
+type Limiter struct {
+	mu     sync.Mutex
+	fileMu sync.Mutex
+	zones  map[string]*zoneBucket
+	limit  int
+	window time.Duration
+	dirty  bool
+	stop   chan struct{}
+	path   string
+}
+
+// New constructs a Limiter, loads any persisted state, and starts the flush
+// loop. limit == 0 disables the cap (probes are still recorded). window == 0
+// is treated as 24h.
+func New(dataDir string, limit int, window time.Duration) *Limiter {
+	if window <= 0 {
+		window = 24 * time.Hour
+	}
+	wl := &Limiter{
+		zones:  make(map[string]*zoneBucket),
+		limit:  limit,
+		window: window,
+		stop:   make(chan struct{}),
+		path:   filepath.Join(dataDir, "wildcard_probes.tsv"),
+	}
+	wl.load()
+	go wl.flushLoop()
+	return wl
+}
+
+// Allow reports whether a new issuance for zone is permitted. Each call —
+// allowed or not — is recorded so denied attempts are visible in the TSV.
+func (wl *Limiter) Allow(zone string) bool {
+	now := time.Now()
+	wl.mu.Lock()
+	defer wl.mu.Unlock()
+
+	bucket, ok := wl.zones[zone]
+	if !ok {
+		bucket = &zoneBucket{}
+		wl.zones[zone] = bucket
+	}
+	cutoff := now.Add(-wl.window)
+	bucket.WindowTimes = trimBefore(bucket.WindowTimes, cutoff)
+
+	if wl.limit > 0 && len(bucket.WindowTimes) >= wl.limit {
+		bucket.LastDeniedAt = now
+		bucket.TotalDenied++
+		wl.dirty = true
+		return false
+	}
+	bucket.WindowTimes = append(bucket.WindowTimes, now)
+	bucket.LastIssuedAt = now
+	bucket.TotalIssued++
+	wl.dirty = true
+	return true
+}
+
+// RecordProbe notes that a probe determined whether zone is served by a
+// wildcard. It does not affect the rate limit.
+func (wl *Limiter) RecordProbe(zone string, isWildcard bool) {
+	if !isWildcard {
+		return
+	}
+	wl.mu.Lock()
+	defer wl.mu.Unlock()
+	bucket, ok := wl.zones[zone]
+	if !ok {
+		bucket = &zoneBucket{}
+		wl.zones[zone] = bucket
+	}
+	bucket.ProbeHits++
+	wl.dirty = true
+}
+
+// Shutdown flushes pending state to disk and stops the background flush loop.
+func (wl *Limiter) Shutdown() {
+	close(wl.stop)
+	wl.flush()
+}
+
+func (wl *Limiter) flushLoop() {
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			wl.flush()
+		case <-wl.stop:
+			return
+		}
+	}
+}
+
+func (wl *Limiter) flush() {
+	wl.fileMu.Lock()
+	defer wl.fileMu.Unlock()
+
+	wl.mu.Lock()
+	if !wl.dirty {
+		wl.mu.Unlock()
+		return
+	}
+
+	var buf strings.Builder
+	w := csv.NewWriter(&buf)
+	w.Comma = '\t'
+	_ = w.Write([]string{"zone", "last_issued_at", "last_denied_at", "window_count", "total_issued", "total_denied", "probe_hits"})
+	for zone, bucket := range wl.zones {
+		_ = w.Write([]string{
+			zone,
+			formatTime(bucket.LastIssuedAt),
+			formatTime(bucket.LastDeniedAt),
+			strconv.Itoa(len(bucket.WindowTimes)),
+			strconv.FormatUint(bucket.TotalIssued, 10),
+			strconv.FormatUint(bucket.TotalDenied, 10),
+			strconv.FormatUint(bucket.ProbeHits, 10),
+		})
+	}
+	w.Flush()
+	wl.mu.Unlock()
+
+	tmp := wl.path + ".tmp"
+	_ = os.MkdirAll(filepath.Dir(wl.path), 0o700)
+	if err := os.WriteFile(tmp, []byte(buf.String()), 0o644); err != nil {
+		log().Warn("failed to write", "path", tmp, "err", err)
+		return
+	}
+	_ = os.Remove(wl.path + ".bak")
+	if _, err := os.Stat(wl.path); err == nil {
+		if err := os.Rename(wl.path, wl.path+".bak"); err != nil {
+			log().Warn("failed to backup", "path", wl.path, "err", err)
+			return
+		}
+	}
+	if err := os.Rename(tmp, wl.path); err != nil {
+		log().Warn("failed to rename", "path", wl.path, "err", err)
+		return
+	}
+
+	wl.mu.Lock()
+	wl.dirty = false
+	wl.mu.Unlock()
+}
+
+func (wl *Limiter) load() {
+	f, err := os.Open(wl.path)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+
+	r := csv.NewReader(f)
+	r.Comma = '\t'
+	r.Comment = '#'
+	r.FieldsPerRecord = -1
+
+	rows, err := r.ReadAll()
+	if err != nil {
+		log().Warn("failed to read", "path", wl.path, "err", err)
+		return
+	}
+
+	cutoff := time.Now().Add(-wl.window)
+	for _, fields := range rows {
+		if len(fields) < 7 {
+			continue
+		}
+		if fields[0] == "zone" {
+			continue
+		}
+		bucket := &zoneBucket{}
+		bucket.LastIssuedAt = parseTime(fields[1])
+		bucket.LastDeniedAt = parseTime(fields[2])
+		bucket.TotalIssued, _ = strconv.ParseUint(fields[4], 10, 64)
+		bucket.TotalDenied, _ = strconv.ParseUint(fields[5], 10, 64)
+		bucket.ProbeHits, _ = strconv.ParseUint(fields[6], 10, 64)
+
+		// Reconstruct an approximate window from the last issuance: if the
+		// most recent issuance still falls inside the window, assume the
+		// recorded window_count remains current. Persisted timestamps for
+		// every issuance would be more accurate but balloon the TSV size.
+		windowCount, _ := strconv.Atoi(fields[3])
+		if !bucket.LastIssuedAt.IsZero() && bucket.LastIssuedAt.After(cutoff) && windowCount > 0 {
+			for range windowCount {
+				bucket.WindowTimes = append(bucket.WindowTimes, bucket.LastIssuedAt)
+			}
+		}
+		wl.zones[fields[0]] = bucket
+	}
+}
+
+func trimBefore(times []time.Time, cutoff time.Time) []time.Time {
+	i := 0
+	for ; i < len(times); i++ {
+		if times[i].After(cutoff) {
+			break
+		}
+	}
+	return times[i:]
+}
+
+func formatTime(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339)
+}
+
+func parseTime(s string) time.Time {
+	if s == "" {
+		return time.Time{}
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return time.Time{}
+	}
+	return t
+}

--- a/issuancegate.go
+++ b/issuancegate.go
@@ -1,0 +1,101 @@
+package tlsrouter
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+)
+
+// staticMatch is the result of walking the static config for an issuance name.
+type staticMatch int
+
+const (
+	staticNoMatch  staticMatch = iota // not present in backends.csv at all
+	staticExplicit                    // exact (non-wildcard) match
+	staticWildcard                    // matched a *.example.com row
+)
+
+// classifyStatic walks the loaded Config for name and reports how it matches
+// static rows. For wildcard matches it also returns the AskURL configured on
+// the service. Returns (staticNoMatch, "") if no static row matches.
+func classifyStatic(conf *Config, name string) (staticMatch, string) {
+	name = strings.ToLower(name)
+
+	if conf == nil {
+		return staticNoMatch, ""
+	}
+
+	for _, dom := range conf.AdminDNS.Domains {
+		if strings.ToLower(dom) == name {
+			return staticExplicit, ""
+		}
+	}
+
+	for _, app := range conf.Apps {
+		if app.Disabled {
+			continue
+		}
+		for _, srv := range app.Services {
+			if srv.Disabled {
+				continue
+			}
+			for _, dom := range srv.Domains {
+				dom = strings.ToLower(dom)
+				if dom == name {
+					return staticExplicit, ""
+				}
+				if rest, ok := strings.CutPrefix(dom, "*."); ok {
+					if name == rest || strings.HasSuffix(name, "."+rest) {
+						return staticWildcard, srv.AskURL
+					}
+				}
+			}
+		}
+	}
+	return staticNoMatch, ""
+}
+
+// decideIssuance is the certmagic OnDemandConfig.DecisionFunc body. It
+// authorizes ACME issuance for name based on static config classification
+// (explicit-pass, wildcard-via-ask_url) and a DNS-probe + rate-limit gate
+// for dynamic CNAME-resolved names.
+func (lc *ListenConfig) decideIssuance(ctx context.Context, name string) error {
+	conf := lc.LoadConfig()
+
+	match, askURL := classifyStatic(&conf, name)
+	switch match {
+	case staticExplicit:
+		return nil
+	case staticWildcard:
+		if askURL == "" {
+			slog.Warn("refusing ACME issuance for wildcard match with no ask_url", "domain", name)
+			return fmt.Errorf("wildcard match for %q has no ask_url configured", name)
+		}
+		return askURLAllows(ctx, askURL, name)
+	}
+
+	if len(lc.ipDomains) == 0 {
+		return fmt.Errorf("no static or dynamic route for %q; refusing issuance", name)
+	}
+
+	isWildcard, parent, err := isWildcardParent(ctx, lc.dns, lc.ipDomains, name)
+	if err != nil {
+		return fmt.Errorf("wildcard probe failed for %q: %w", name, err)
+	}
+	if !isWildcard {
+		slog.Debug("dynamic issuance allowed: parent is not a wildcard", "domain", name, "parent", parent)
+		return nil
+	}
+
+	if lc.wildcardLimiter == nil {
+		return fmt.Errorf("wildcard parent zone %q detected but no rate limiter configured", parent)
+	}
+	lc.wildcardLimiter.RecordProbe(parent, true)
+	if !lc.wildcardLimiter.Allow(parent) {
+		slog.Warn("wildcard rate limit reached; refusing ACME issuance", "domain", name, "parent", parent)
+		return fmt.Errorf("wildcard rate limit reached for parent zone %q", parent)
+	}
+	slog.Info("wildcard ACME issuance permitted under rate limit", "domain", name, "parent", parent)
+	return nil
+}

--- a/skills/tlsrouter-deploy-test/scripts/test-health.sh
+++ b/skills/tlsrouter-deploy-test/scripts/test-health.sh
@@ -34,6 +34,10 @@ echo ""
 check "HTTPS reachable" "200" "https://${g_domain}/version"
 check "HTTP redirect" "301" "http://${g_domain}/"
 
+if test "$g_domain" = "vms.oneal.im"; then
+	check "CNAME chain (2-hop)" "200" "https://testchaining.oneal.im/version"
+fi
+
 echo ""
 echo "Results: $g_pass passed, $g_fail failed"
 

--- a/tlsrouter.go
+++ b/tlsrouter.go
@@ -35,6 +35,7 @@ import (
 	"github.com/bnnanet/tlsrouter/dnsresolver"
 	"github.com/bnnanet/tlsrouter/internal/conntracker"
 	"github.com/bnnanet/tlsrouter/internal/ipgate"
+	"github.com/bnnanet/tlsrouter/internal/wildcardlimit"
 	"github.com/bnnanet/tlsrouter/net/tun"
 	"github.com/bnnanet/tlsrouter/tabvault"
 
@@ -83,6 +84,12 @@ type Config struct {
 	Networks              []net.IPNet        `json:"dynamic_host_networks"`
 	IPDomains             []string           `json:"dynamic_ip_domains"`
 	IPs                   []net.IP           `json:"-"`
+	// WildcardRateLimit caps ACME issuances per wildcard parent zone within
+	// WildcardRateWindow. The cap applies only to names served by an
+	// upstream wildcard CNAME into one of IPDomains, detected at issuance
+	// time via DNS probe. Zero disables the cap.
+	WildcardRateLimit  int           `json:"-"`
+	WildcardRateWindow time.Duration `json:"-"`
 }
 
 // ShortSHA2 is not safe for use after atomic Store()
@@ -180,6 +187,11 @@ type ConfigService struct {
 	Backends               []Backend      `json:"backends"`
 	CurrentBackend         *atomic.Uint32 `json:"-"`
 	AllowedClientHostnames []string       `json:"allowed_client_hostnames,omitempty"`
+	// AskURL gates ACME issuance for wildcard domains: tlsrouter does
+	// GET <AskURL>?domain=<sni> and only requests a certificate if the
+	// response is HTTP 200. Empty AskURL on a wildcard service refuses
+	// issuance (fail-closed).
+	AskURL string `json:"ask_url,omitempty"`
 }
 
 func (srv *ConfigService) GenSlug() string {
@@ -304,6 +316,8 @@ type ListenConfig struct {
 	serviceMu             sync.RWMutex
 	resolveGroup          singleflight.Group
 	connTracker           *conntracker.Tracker
+	wildcardLimiter       *wildcardlimit.Limiter
+	ipDomains             []string
 }
 
 // TODO move to *Listener
@@ -312,6 +326,9 @@ func (lc *ListenConfig) Shutdown(ctx context.Context) {
 	// TODO create a context with a 5 second timeout and
 	_ = lc.adminServer.Shutdown(ctx)
 	lc.connTracker.Shutdown()
+	if lc.wildcardLimiter != nil {
+		lc.wildcardLimiter.Shutdown()
+	}
 	lc.done <- ctx
 }
 
@@ -361,6 +378,8 @@ func NewListenConfig(conf Config) *ListenConfig {
 		Blocklist:             ipgate.EmptyPrefixSet(),
 		AllowList:             ipgate.EmptyDomainSet(),
 		connTracker:           conntracker.New(dataDir()),
+		wildcardLimiter:       wildcardlimit.New(dataDir(), conf.WildcardRateLimit, conf.WildcardRateWindow),
+		ipDomains:             conf.IPDomains,
 		slowACMETLS1ByDomain:  make(map[string]*Backend),
 		Context:               ctx,
 		Close:                 cancel,
@@ -799,7 +818,7 @@ func (lc *ListenConfig) newCertmagicTLSALPNOnly() *certmagic.Config {
 	magic := certmagic.New(lc.certmagicCache, certmagic.Config{
 		RenewalWindowRatio: 0.3,
 		OnDemand: &certmagic.OnDemandConfig{
-			DecisionFunc: nil, // use ManageSync() allowlist
+			DecisionFunc: lc.decideIssuance,
 		},
 		OnEvent: func(ctx context.Context, eventName string, data map[string]any) error {
 			if eventName != "cert_obtaining" {
@@ -836,7 +855,7 @@ func (lc *ListenConfig) newCertmagic(dnsProvider certmagic.DNSProvider) *certmag
 	magic := certmagic.New(lc.certmagicCache, certmagic.Config{
 		RenewalWindowRatio: 0.3,
 		OnDemand: &certmagic.OnDemandConfig{
-			DecisionFunc: nil, // use ManageSync() allowlist
+			DecisionFunc: lc.decideIssuance,
 		},
 		OnEvent: func(ctx context.Context, eventName string, data map[string]any) error {
 			if eventName != "cert_obtaining" {

--- a/wildcardprobe.go
+++ b/wildcardprobe.go
@@ -1,0 +1,82 @@
+package tlsrouter
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/bnnanet/tlsrouter/dnsresolver"
+)
+
+// probeLabelPrefix is the leading label used for wildcard-detection lookups.
+// Operators inspecting DNS query logs can recognize these and ignore them.
+const probeLabelPrefix = "tlsrouter-probe-"
+
+// parentZone returns the zone one label above name, e.g.
+// "foo.apps.example.net" -> "apps.example.net". Returns "" if name has no
+// dot (single-label, like a TLD) and can't be probed safely.
+func parentZone(name string) string {
+	i := strings.IndexByte(name, '.')
+	if i < 0 || i == len(name)-1 {
+		return ""
+	}
+	return name[i+1:]
+}
+
+// isWildcardParent probes for a wildcard CNAME at the parent zone of name. It
+// looks up a random subdomain of parentZone(name) and reports true if the
+// terminal CNAME falls under one of the configured IPDomains — i.e. the
+// parent is set up as `*.parent CNAME tls-X.<ipdomain>` (or similar) and any
+// arbitrary subdomain would resolve into our infrastructure.
+//
+// A "false, nil" result means the parent is not a wildcard (the probe got
+// NXDOMAIN, or the chain terminates outside our IPDomains). A non-nil error
+// means we couldn't determine the answer (transient DNS failure); callers
+// should fail closed.
+func isWildcardParent(ctx context.Context, dns *dnsresolver.Resolver, ipDomains []string, name string) (bool, string, error) {
+	parent := parentZone(name)
+	if parent == "" {
+		return false, "", fmt.Errorf("cannot probe parent zone of %q", name)
+	}
+
+	label, err := randomProbeLabel()
+	if err != nil {
+		return false, parent, err
+	}
+	probe := label + "." + parent
+
+	cname, _, err := dns.LookupCNAME(ctx, probe)
+	if err != nil {
+		// LookupCNAME returns an error for NXDOMAIN / no-A-record terminations,
+		// which is exactly the "not a wildcard" case. Distinguish that from a
+		// genuine resolver failure by checking for the sentinel.
+		if errors.Is(err, dnsresolver.ErrNoARecord) {
+			slog.Debug("wildcard probe: no A record (not a wildcard)", "probe", probe, "domain", name)
+			return false, parent, nil
+		}
+		return false, parent, fmt.Errorf("probe %q: %w", probe, err)
+	}
+
+	cname = strings.TrimSuffix(strings.ToLower(cname), ".")
+	for _, ipDomain := range ipDomains {
+		suffix := "." + strings.ToLower(ipDomain)
+		if strings.HasSuffix(cname, suffix) {
+			slog.Info("wildcard probe: parent zone is wildcard into IPDomain", "domain", name, "parent", parent, "probe", probe, "terminal", cname)
+			return true, parent, nil
+		}
+	}
+	slog.Debug("wildcard probe: parent resolves outside IPDomains (not our wildcard)", "probe", probe, "terminal", cname)
+	return false, parent, nil
+}
+
+func randomProbeLabel() (string, error) {
+	b := make([]byte, 6)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return probeLabelPrefix + hex.EncodeToString(b), nil
+}


### PR DESCRIPTION
## What

Add a certmagic `OnDemand` `DecisionFunc` that classifies each cert issuance request by how the SNI matches config:

- **Explicit static rows** (`backends.csv`) — allowed unconditionally
- **Wildcard static rows** (`*.example.com`) — must declare an `ask_url`; tlsrouter GETs `<ask_url>?domain=<sni>` and only proceeds on HTTP 200. Missing `ask_url` on a wildcard row fails closed.
- **Dynamic CNAME-resolved names** — probe `tlsrouter-probe-<hex>.<parent>` via `LookupCNAME`. If the parent zone is a wildcard CNAME into a configured IPDomain, apply a sliding-window per-zone cap (`--wildcard-rate-limit` / `--wildcard-rate-window`, defaults 10/24h). Specific records (probe NXDOMAIN) pass through unchanged.

Counters and probe hits persist to `wildcard_probes.tsv` alongside `connections.tsv` (same atomic `.tmp/.bak/rename` pattern, 5-minute flush), so the rate limit survives restarts.

## Test plan

- [ ] Verify wildcard cert gating rejects unauthorized domains via `ask_url`
- [ ] Verify rate limit blocks issuance after threshold
- [ ] `test-health.sh vms.oneal.im` passes CNAME chain test