### PR TITLE
fix(dns): reject no-SNI connections at TLS handshake

### DIFF
--- a/dnsresolver/resolver.go
+++ b/dnsresolver/resolver.go
@@ -72,7 +72,7 @@ func (r *Resolver) LookupCNAME(ctx context.Context, domain string) (string, uint
 	}
 
 	maxHops := cmp.Or(r.MaxCNAMEHops, DefaultMaxCNAMEHops)
-	if len(resp.Answer) > maxHops {
+	if len(resp.Answer) == 0 || len(resp.Answer) > maxHops {
 		return "", 0, fmt.Errorf("%s: did not resolve to A record within %d hops: %w", domain, maxHops, ErrNoARecord)
 	}
 	if _, ok := resp.Answer[len(resp.Answer)-1].(*dns.A); !ok {

--- a/tlsrouter.go
+++ b/tlsrouter.go
@@ -1017,6 +1017,10 @@ func (lc *ListenConfig) proxy(conn net.Conn) (r int64, w int64, retErr error) {
 
 			slog.Info("connect", "src", hello.Conn.RemoteAddr(), "domain", domain, "alpn", strings.Join(alpns, ","))
 
+			if domain == "" {
+				return nil, fmt.Errorf("no SNI")
+			}
+
 			if alpns[0] == acmez.ACMETLS1Protocol {
 				dbg("DEBUG: %s: handling acme ALPN challenge", domain)
 				// note: certmagicConfMap only holds backends that terminate


### PR DESCRIPTION
Regression introduced by Opus.

## What

Clients connecting without SNI (`domain = ""`) crashed tlsrouter every few hours.

**Root cause:** no-SNI connections bypassed all cache and static lookups and fell through to `LookupCNAME("")`. DNS for `""` (which becomes `"."`) returns an empty Answer section. `LookupCNAME` checked `len > maxHops` but not `len == 0`, so `resp.Answer[len-1]` indexed at `-1` and panicked. The panic fired inside a `wg.Go` goroutine, escaping the per-connection `recover()` and crashing the process.

**Fixes:**

- `tlsrouter.go`: return `fmt.Errorf("no SNI")` from `GetConfigForClient` immediately after logging the connect event — no-SNI connections never reach routing logic
- `dnsresolver/resolver.go`: add `len(resp.Answer) == 0` guard in `LookupCNAME` as defense-in-depth

## Test plan

- [x] Deployed to test instance, health checks pass
- [x] Observed crash in logs at 03:00:16; no recurrence after deploy