### PR TITLE
docs: add TLS Router troubleshooting section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,3 +147,71 @@ ssh vms.example.com "sudo journalctl -u tlsrouter --no-pager -n 20"
 | postgresql | 5432 | 15432 |
 | tds/8.0 | 1433 | 11433 |
 | mysql | 3306 | 13306 |
+
+## Troubleshooting
+
+### SRV Record Caching — Stale IPs After DNS Updates
+
+The TLS Router caches SRV and CNAME lookups with a TTL of 30 seconds to 10 minutes (min/max bounds from DNS TTL). **When you update an SRV record to point to a new IP, the old record may still be served from cache.**
+
+**Symptoms:** TLS Router logs show `dial tcp <old-ip>:3080: i/o timeout` for a domain whose SRV record has been updated.
+
+**Fix:** Restart the tlsrouter service to clear the DNS cache:
+
+```sh
+ssh vms.example.com "sudo systemctl restart tlsrouter"
+```
+
+A reload (`SIGUSR1` / `systemctl reload`) does **not** clear the cache — only a full stop/start does.
+
+### ALPN Name Translation — Multiple SRV Records for Same Service
+
+The TLS Router translates ALPN names to SRV service names in two ways:
+1. Replace all `.` with `-`, replace `/` with `_` → `http/1.1` becomes `_http_1-1`
+2. Drop anything after `/`, replace `.` with `-` → `http/1.1` becomes `_http`
+
+This means **both** `_http._tcp.example.com` and `_http_1-1._tcp.example.com` can exist for the same domain. If you change your SRV record from the verbose form (`_http_1-1`) to the shorthand (`_http`), the old `_http_1-1` record may still be cached and matched first.
+
+**Example:**
+
+```text
+# Old record (verbose form) — may still be cached
+SRV     _http_1-1._tcp.example.com   10 3080 tls-10-11-2-21.vms.example.com  300
+
+# New record (shorthand form)
+SRV     _http._tcp.example.com       10 3080 tls-10-11-2-30.vms.example.com  300
+```
+
+If the old record is still cached, the TLS Router will route to `10.11.2.21` instead of `10.11.2.30`. **Restart tlsrouter after any SRV record change** to avoid stale routing.
+
+### Debugging Steps
+
+1. Check the TLS Router logs for the backend IP it's trying to reach:
+   ```sh
+   ssh vms.example.com "sudo journalctl -xeu tlsrouter --no-pager -n 100" | grep -i "error\|dial\|reverse"
+   ```
+
+2. Verify the SRV record resolves to the correct IP:
+   ```sh
+   dig +short SRV _http._tcp.example.com
+   dig +short tls-10-11-2-30.vms.example.com
+   ```
+
+3. Test the backend directly from the vms host:
+   ```sh
+   ssh app@vms.example.com "curl -s http://10.11.2.30:3080/"
+   ```
+
+4. If the backend is reachable but the TLS Router still fails, **restart** (not reload) the tlsrouter service.
+
+5. Check for stale static backends.csv entries that may conflict with dynamic DNS:
+   ```sh
+   ssh app@vms.example.com "grep '<domain>' ~/.config/tlsrouter/backends.csv"
+   ```
+
+### Common Pitfalls
+
+- **Reload ≠ restart**: `systemctl reload tlsrouter` sends SIGUSR1 which reloads config but does NOT clear the DNS cache. Use `systemctl restart` to clear caches.
+- **CNAME vs SRV**: Only one CNAME can be active per domain. If you switch from CNAME to SRV (or vice versa), the old record may linger in cache.
+- **Multiple SRV records**: If you have both `_http._tcp` and `_http_1-1._tcp` for the same domain, the TLS Router may match whichever it encounters first. Clean up old records.
+- **Port mismatches**: The SRV port must match the expected port for the ALPN. For `http/1.1`, the SRV port must be `3080`. For `ssh`, it must be `22`. Arbitrary ports are rejected for security.


### PR DESCRIPTION
## What

Add a new `## Troubleshooting` section to `AGENTS.md` covering TLS Router + SRV dynamic config.

## Content

- **SRV Record Caching** — explain that the TLS Router caches DNS lookups (30s–10min TTL) and a full restart (not reload) is needed to clear stale entries after DNS updates
- **ALPN Name Translation** — document that `http/1.1` maps to both `_http._tcp` and `_http_1-1._tcp` SRV records, and old records may be cached and matched first
- **Debugging Steps** — practical commands for checking TLS Router logs, verifying SRV records, and testing backends
- **Common Pitfalls** — reload ≠ restart, CNAME vs SRV conflicts, multiple SRV records, port mismatches
