### PR TITLE
fix: resolve 'http' ALPN shorthand to client-offered HTTP-family ALPN

### DIFF
--- a/dynamic-config.go
+++ b/dynamic-config.go
@@ -453,11 +453,19 @@ func findSrvForALPN(
 		// http/1.1 => http
 		// tds/8.0 => tds
 		// stun.turn => stun-turn
-		service = strings.Split(alpn, "/")[0]
+		shorthand := strings.Split(alpn, "/")[0]
 		// no known ALPNs have both dots in the name and in versions,
 		// so this is just for future-proofing, ex: stun.turn/2.0
-		service = strings.ReplaceAll(service, ".", "-")
-		return findSrvForALPN(ctx, dns, conf, domain, service)
+		shorthand = strings.ReplaceAll(shorthand, ".", "-")
+		// fall back to shorthand SRV lookup, but preserve the original ALPN
+		if route, err := findSrvForALPN(ctx, dns, conf, domain, shorthand); err == nil {
+			route.ALPN = alpn
+			return route, nil
+		}
+		if err != nil {
+			return nil, err
+		}
+		return nil, errTryNext
 	}
 
 	if err != nil {

--- a/tlsrouter.go
+++ b/tlsrouter.go
@@ -1155,10 +1155,21 @@ func (lc *ListenConfig) proxy(conn net.Conn) (r int64, w int64, retErr error) {
 			dbg("DEBUG: %s: GetConfigForClient: return tls.Config with cached certmagic m.GetCertificate", snialpn)
 			_ = wconn.Passthru()
 
+			alpn := snialpn.ALPN()
+			// "http" is a config shorthand — resolve to the first HTTP-family ALPN
+			// the client actually offered (h2, http/1.1, etc.)
+			if alpn == "http" {
+				for _, offered := range hello.SupportedProtos {
+					if slices.Contains(HTTPFamilyALPNs, offered) {
+						alpn = offered
+						break
+					}
+				}
+			}
 			return &tls.Config{
 				// Certificates: []tls.Certificate{*tlsCert},
 				GetCertificate: magic.GetCertificate,
-				NextProtos:     []string{snialpn.ALPN()},
+				NextProtos:     []string{alpn},
 			}, nil
 		},
 	})


### PR DESCRIPTION
## Problem

When a domain has an SRV record using the shorthand `_http._tcp` (e.g. `_http._tcp.oneal.im`), clients offering ALPNs like `[h2, http/1.1]` get a handshake failure:

```
tls: client requested unsupported application protocols (["h2" "http/1.1"])
```

The server advertises `NextProtos: ["http"]` — the config shorthand — but the client never offers `"http"` as a wire ALPN.

## Root Cause

Two issues in the SRV resolution path:

1. **`findSrvForALPN`** (dynamic-config.go): When falling back from `http/1.1` → `http` for SRV lookup, the returned route overwrote the original ALPN with the shorthand `"http"`.

2. **`GetConfigForClient`** (tlsrouter.go): Used `snialpn.ALPN()` directly for `NextProtos`, which was `"http"` — not a real wire ALPN.

## Fix

1. **dynamic-config.go**: On SRV fallback, preserve the original ALPN in the returned route (`route.ALPN = alpn`).

2. **tlsrouter.go**: When the matched ALPN is the shorthand `"http"`, resolve it to the first HTTP-family ALPN the client actually offered from `hello.SupportedProtos` (e.g. `h2` or `http/1.1`).

## Changes

- `dynamic-config.go`: `findSrvForALPN` fallback preserves original ALPN
- `tlsrouter.go`: `GetConfigForClient` resolves `"http"` shorthand to client-offered HTTP-family ALPN
